### PR TITLE
Deploy with node runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@ Form Builder Publisher Web application
 
 # Pre-requisites
 
+### To run the web app only
 * ruby (2.5.0)
 * [rubygems](https://rubygems.org/)
 * [bundler](https://bundler.io/)
 * [postgresql](https://www.postgresql.org/) - v10.3+
-* (optional) [Docker](https://docker.com/) - tested on 18.03.1
+
+### To perform deployments
+* [Docker](https://docker.com/) - tested on 18.03.1
+* [Kubernetes](https://kubernetes.io/) - Homebrew package `kubernetes-cli` v1.11+
+
+### To run deployed services locally
+* [Minikube](https://github.com/kubernetes/minikube) - v0.26.1+
 
 # Setup
 

--- a/app/jobs/deploy_service_job.rb
+++ b/app/jobs/deploy_service_job.rb
@@ -25,16 +25,16 @@ class DeployServiceJob < ApplicationJob
       image: built_service[:tag],
       environment_slug: deployment.environment_slug
     )
-    DeploymentService.configure(
-      config_dir: config_dir,
-      environment_slug: deployment.environment_slug,
-      service: deployment.service
-    )
     DeploymentService.restart(
       environment_slug: deployment.environment_slug,
       service: deployment.service,
       tag: built_service[:tag]
     )
 
+    DeploymentService.configure(
+      config_dir: config_dir,
+      environment_slug: deployment.environment_slug,
+      service: deployment.service
+    )
   end
 end

--- a/app/jobs/deploy_service_job.rb
+++ b/app/jobs/deploy_service_job.rb
@@ -30,7 +30,7 @@ class DeployServiceJob < ApplicationJob
       environment_slug: deployment.environment_slug,
       service: deployment.service
     )
-    DeploymentService.start(
+    DeploymentService.restart(
       environment_slug: deployment.environment_slug,
       service: deployment.service,
       tag: built_service[:tag]

--- a/app/jobs/deploy_service_job.rb
+++ b/app/jobs/deploy_service_job.rb
@@ -2,16 +2,20 @@ class DeployServiceJob < ApplicationJob
   queue_as :default
 
   def perform(service_deployment_id:, json_sub_dir: nil)
-    # Check out the code
     deployment = ServiceDeployment.find(service_deployment_id)
+
+    # Check out the code
     json_dir = File.join(temp_dir, 'json')
     config_dir = File.join(temp_dir, 'config')
     GitService.clone_repo(repo_url: deployment.service.git_repo_url, to_dir: json_dir)
+    GitService.checkout(ref: deployment.commit_sha, dir: json_dir)
+    deployment.commit_sha = GitService.current_commit_sha(dir: json_dir, short: true)
+
 
     # if the json we want is not in the root of the repo,
     # from now on we need to work in that sub dir
     json_dir = File.join(json_dir, json_sub_dir) if json_sub_dir.present?
-    
+
     built_service = DeploymentService.build(
       environment_slug: deployment.environment_slug,
       service: deployment.service,

--- a/app/services/cloud_platform_adapter.rb
+++ b/app/services/cloud_platform_adapter.rb
@@ -1,0 +1,16 @@
+class CloudPlatformAdapter
+  # can be called before the service is deployed
+  def self.url_for(service:, environment_slug:)
+    ServiceEnvironment.find(environment_slug).url_for(service)
+  end
+
+  def self.service_url(service:, environment_slug:)
+    environment = ServiceEnvironment.find(environment_slug)
+    KubernetesAdapter.service_url(
+      service: service,
+      environment_slug: environment_slug,
+      context: environment.kubectl_context,
+      namespace: environment.namespace
+    )
+  end
+end

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -31,8 +31,13 @@ class DeploymentService
     [['fb', service.slug, environment_slug].join('-'), version].join(':')
   end
 
-  def self.build(environment_slug:, service:, json_dir:)
-    tag = service_tag(environment_slug: environment_slug, service: service)
+  # TODO: better version mgmt! Something semantic, or the hash?
+  def self.build(environment_slug:, service:, json_dir:, tag: nil)
+
+    tag ||= service_tag(environment_slug: environment_slug,
+                        service: service,
+                        version: GitService.current_commit_sha(dir: json_dir))
+
     LocalDockerService.build(
       tag: tag,
       json_dir: json_dir
@@ -63,6 +68,14 @@ class DeploymentService
       environment_slug: environment_slug,
       service: service,
       tag: tag
+    )
+  end
+
+  def self.url_for(environment_slug:, service:)
+    adapter = adapter_for(environment_slug)
+    adapter.url_for(
+      environment_slug: environment_slug,
+      service: service
     )
   end
 

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -71,6 +71,20 @@ class DeploymentService
       stop(environment_slug: environment_slug, service: service)
     end
 
+    if adapter.deployment_exists?(
+      environment_slug: environment_slug,
+      service: service
+    )
+      begin
+        adapter.delete_deployment(
+          environment_slug: environment_slug,
+          service: service
+        )
+      rescue CmdFailedError => e
+        false
+      end
+    end
+
     start(environment_slug: environment_slug, service: service, tag: tag)
   end
 

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -106,6 +106,7 @@ class DeploymentService
   end
 
   def self.url_for(environment_slug:, service:)
+    BLAH
     adapter = adapter_for(environment_slug)
     begin
       adapter.url_for(

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -62,6 +62,26 @@ class DeploymentService
     )
   end
 
+  def self.restart(environment_slug:, service:, tag:)
+    adapter = adapter_for(environment_slug)
+    if adapter.service_is_running?(
+      environment_slug: environment_slug,
+      service: service
+    )
+      stop(environment_slug: environment_slug, service: service)
+    end
+
+    start(environment_slug: environment_slug, service: service, tag: tag)
+  end
+
+  def self.stop(environment_slug:, service:)
+    adapter = adapter_for(environment_slug)
+    adapter.stop(
+      environment_slug: environment_slug,
+      service: service
+    )
+  end
+
   def self.start(environment_slug:, service:, tag:)
     adapter = adapter_for(environment_slug)
     adapter.start(

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -73,10 +73,15 @@ class DeploymentService
 
   def self.url_for(environment_slug:, service:)
     adapter = adapter_for(environment_slug)
-    adapter.url_for(
-      environment_slug: environment_slug,
-      service: service
-    )
+    begin
+      adapter.url_for(
+        environment_slug: environment_slug,
+        service: service
+      )
+    rescue CmdFailedError => e
+      # might not have been deployed yet
+      nil
+    end
   end
 
   private

--- a/app/services/git_service.rb
+++ b/app/services/git_service.rb
@@ -9,11 +9,17 @@ class GitService
     end
   end
 
+  def self.current_commit_sha(dir:, short: true)
+    short_arg = (short ? '--short' : '')
+    Dir.chdir(dir) do
+      ShellAdapter.output_of(git_binary, 'rev-parse', short_arg, 'HEAD')
+    end
+  end
 
   private
 
   def self.git_binary
-    "$(which git)"
+    @git_binary ||= ShellAdapter.output_of("which git")
   end
 
 end

--- a/app/services/local_docker_service.rb
+++ b/app/services/local_docker_service.rb
@@ -19,10 +19,10 @@ class LocalDockerService
 
   def self.default_runner_image_ref
     # old c100 prototype runner
-    "aldavidson/fb-sample-runner:latest"
+    # "aldavidson/fb-sample-runner:latest"
 
     # shiny new general-purpose runner:
-    # "aldavidson/fb-runner-node:latest"
+    "aldavidson/fb-runner-node:latest"
   end
 
   def self.service_dockerfile_path

--- a/app/services/shell_adapter.rb
+++ b/app/services/shell_adapter.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 class ShellAdapter
   def self.exec(binary, *args)
     cmd_line = build_cmd( executable: binary, args: args )
@@ -6,6 +8,22 @@ class ShellAdapter
     # can get streaming output as well as exit code?
     result = Kernel.system(cmd_line)
     raise CmdFailedError.new(cause: "#{$?}", message: "failing cmd: #{cmd_line}") unless result
+  end
+
+  # NOTE: concatenates a streaming buffer into one string to return
+  # - not scalable to long output!
+  def self.output_of(*args)
+    output = []
+    exit_code = Open3.popen2e(*args) do |stdin, stdout_and_stderr, wait_thread|
+      stdout_and_stderr.each_line do |line|
+        output << line
+      end
+      unless wait_thread.value.success?
+        build_cmd( executable: binary, args: args )
+        raise CmdFailedError.new(cause: "#{$?}", message: "failing cmd: #{cmd_line}")
+      end
+    end
+    output.join('\n').strip
   end
 
   def self.build_cmd(executable:, args: [], redirect_to: nil, pipe_to: nil)

--- a/app/services/shell_adapter.rb
+++ b/app/services/shell_adapter.rb
@@ -19,7 +19,7 @@ class ShellAdapter
         output << line
       end
       unless wait_thread.value.success?
-        build_cmd( executable: binary, args: args )
+        cmd_line = build_cmd( executable: args[0], args: args[1..-1] )
         raise CmdFailedError.new(cause: "#{$?}", message: "failing cmd: #{cmd_line}")
       end
     end

--- a/app/views/services/_environment.html.haml
+++ b/app/views/services/_environment.html.haml
@@ -2,7 +2,10 @@
   %th
     = ServiceEnvironment.find(environment.environment_slug).name
   %td
-    = link_to(environment.url, environment.url)
+    - if environment.url.present?
+      = link_to(environment.url, environment.url)
+    - else
+      \-
   %td
     - if environment.status
       %span{ class: "status status-#{environment.status.to_s.first}xx" }

--- a/app/views/services/deployments/new.html.haml
+++ b/app/views/services/deployments/new.html.haml
@@ -6,6 +6,8 @@
 
 = form_with model: @deployment, url: update_or_create(@deployment), local: true do |f|
   = f.hidden_field :environment_slug
-  = f.text_field :commit_sha, label: nil, required: false, maxlength: 64, size: 32
+
+  = f.text_field :json_sub_dir, required: false, maxlength: 64, size: 32 
+  = f.text_field :commit_sha, required: false, maxlength: 64, size: 32
 
   = f.submit t('.submit'), class: 'button button-cta'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,9 @@ en:
         commit_sha_html:
           <em>(optional)</em> Enter a commit SHA or branch/tag name to deploy<br />
           Or leave it blank, and we'll deploy HEAD (the latest commit)
+        json_sub_dir_html:
+          <em>(optional)</em> If the JSON you want to deploy is in a sub-directory
+          of the repository shown above, please enter the relative path to it here.
     label:
       service:
         git_repo_url: URL of the service config JSON Git repository
@@ -61,6 +64,7 @@ en:
         slug: Service "slug"
       service_deployment:
         commit_sha: Commit SHA, branch, or tag
+        json_sub_dir: Relative path to your service's JSON
   auth:
     existing_user:
       welcome_html: "Welcome back, <strong>%{user_name}</strong>!"
@@ -122,7 +126,7 @@ en:
       new:
         heading: Deploy '%{service}' to %{environment}
         lede_html:
-          Your JSON is at <strong><a href='%{git_repo_url}'>%{git_repo_url}</a></strong>
+          Your JSON repository is at <strong><a href='%{git_repo_url}'>%{git_repo_url}</a></strong>
         submit: Deploy now
       status:
         lede_html:

--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -4,3 +4,4 @@ FROM $RUNNER_IMAGE
 RUN mkdir -p /usr/app/metadata
 ARG JSON_DIR=./json
 COPY $JSON_DIR /usr/app/metadata/
+ENV SITEDATAPATH=/usr/app/metadata/

--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUNNER_IMAGE=aldavidson/fb-sample-runner:latest
+ARG RUNNER_IMAGE=aldavidson/fb-runner-node:latest
 FROM $RUNNER_IMAGE
 
 RUN mkdir -p /usr/app/metadata

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -1,6 +1,10 @@
 require 'capybara_helper'
 
 describe 'visiting /services' do
+  before do
+    allow(DeploymentService).to receive(:url_for).and_return('url.test')
+  end
+  
   context 'as a logged in user' do
     let(:user){ User.create(id: 'abc123', name: 'test user', email: 'test@example.justice.gov.uk') }
     before do

--- a/spec/models/service_status_check_spec.rb
+++ b/spec/models/service_status_check_spec.rb
@@ -4,6 +4,10 @@ require 'webmock/rspec'
 describe ServiceStatusCheck do
   let(:mock_response) { double('response', code: 404) }
 
+  before do
+    allow(DeploymentService).to receive(:url_for).and_return('url.test')
+  end
+
   describe '.execute!' do
     before do
       allow_any_instance_of(described_class).to receive(:net_http_response).and_return(mock_response)

--- a/spec/models/service_status_check_spec.rb
+++ b/spec/models/service_status_check_spec.rb
@@ -27,8 +27,9 @@ describe ServiceStatusCheck do
     let(:dev_response) { {status: 200} }
     let(:staging_response) { {status: 404} }
     before do
-      WebMock.stub_request(:get, "my-service.minikube.local").to_return(dev_response)
-      WebMock.stub_request(:get, "https://my-service.apps.non-production.k8s.integration.dsd.io/").to_return(staging_response)
+      WebMock.stub_request(:get, "url1").to_return(dev_response)
+      WebMock.stub_request(:get, "url2").to_return(staging_response)
+      # WebMock.stub_request(:get, "https://my-service.apps.non-production.k8s.integration.dsd.io/").to_return(staging_response)
       allow_any_instance_of(ServiceStatusCheck).to receive(:save!)
     end
 
@@ -37,6 +38,10 @@ describe ServiceStatusCheck do
       let(:envs){ [:dev, :staging] }
       let(:result) do
         described_class.execute_many!(service: service, environment_slugs: envs)
+      end
+      before do
+        allow(DeploymentService).to receive(:url_for).with(service: service, environment_slug: 'dev').and_return('url1')
+        allow(DeploymentService).to receive(:url_for).with(service: service, environment_slug: 'staging').and_return('url2')
       end
 
       it 'returns an array of checks' do

--- a/spec/services/status_service_spec.rb
+++ b/spec/services/status_service_spec.rb
@@ -93,8 +93,9 @@ describe StatusService do
       it 'has the given environment_slug as a string' do
         expect(return_value.environment_slug).to eq('dev')
       end
-      it 'has url populated' do
-        expect(return_value.url).to_not be_empty
+
+      it 'has nil url' do
+        expect(return_value.url).to be_nil
       end
     end
   end

--- a/spec/services/status_service_spec.rb
+++ b/spec/services/status_service_spec.rb
@@ -5,6 +5,10 @@ describe StatusService do
   let(:check_dev){ double(ServiceStatusCheck) }
   let(:check_staging){ double(ServiceStatusCheck) }
 
+  before do
+    allow(DeploymentService).to receive(:url_for).and_return('url.test')
+  end
+
 
   describe '.service_status' do
     describe 'given multiple environment_slugs' do
@@ -94,8 +98,8 @@ describe StatusService do
         expect(return_value.environment_slug).to eq('dev')
       end
 
-      it 'has nil url' do
-        expect(return_value.url).to be_nil
+      it 'has whatever url is returned from the deployment service' do
+        expect(return_value.url).to eq('url.test')
       end
     end
   end


### PR DESCRIPTION
Can now run DeployServiceJob against local minikube, without errors, against a new service and an existing service.

CAVEATS:
* minikube service currently has to be deleted and recreated each time for updates to take effect.
* as a result, it may get a different port each time 
* no tests for this whole suite of services & adapters yet (the abstraction layers are still changing rapidly as I get used to this problem space, will add tests once the cloud platform support is there)
