### PR TITLE
Enforce http or file git repo urls

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -353,6 +353,7 @@ class KubernetesAdapter
       containers:
       - name: #{name}
         image: #{image}
+        imagePullPolicy: Always
         ports:
         - containerPort: #{container_port}
         volumeMounts:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
     service:
       git_repo_url:
         not_valid_scheme: "must be a valid https: or file: URL"
-        invalid_uri: is not a valid https: or file: URL
+        invalid_uri: "is not a valid https: or file: URL"
   helpers:
     hint:
       service:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,11 +30,16 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  errors:
+    service:
+      git_repo_url:
+        not_valid_scheme: "must be a valid https: or file: URL"
+        invalid_uri: is not a valid https: or file: URL
   helpers:
     hint:
       service:
         git_repo_url_html:
-          Should be cloneable & readable by an unauthenticated user<br />
+          This must use the <strong>https</strong> scheme (<em>not</em> ssh)<br />
           For example, <a href="https://github.com/ministryofjustice/fb-sample-json.git">https://github.com/ministryofjustice/fb-sample-json.git</a>
         name_html:
           What users will see as the title of your service<br />

--- a/db/migrate/20180713102948_update_all_ssh_git_repo_urls_to_https.rb
+++ b/db/migrate/20180713102948_update_all_ssh_git_repo_urls_to_https.rb
@@ -1,0 +1,13 @@
+class UpdateAllSshGitRepoUrlsToHttps < ActiveRecord::Migration[5.2]
+  def change
+    Service.all.each do |service|
+      if service.git_repo_url =~ /git@github.com:/
+        https_url = service.git_repo_url.gsub('git@github.com:', 'https://github.com/')
+        Rails.logger.info [service.slug, service.git_repo_url, https_url].join("=>")
+        service.update_attributes(
+          git_repo_url: https_url
+        )
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_12_102803) do
+ActiveRecord::Schema.define(version: 2018_07_13_102948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -64,6 +64,75 @@ describe Service do
         end
       end
     end
+
+    context 'with a git_repo_url' do
+      before do
+        subject.git_repo_url = git_repo_url
+      end
+
+      context 'that is empty' do
+        let(:git_repo_url) { nil }
+
+        it 'adds an error on git_repo_url' do
+          subject.valid?
+          expect(subject.errors[:git_repo_url]).to_not be_empty
+        end
+      end
+
+      context 'that is too short' do
+        let(:git_repo_url) { 'a' }
+
+        it 'adds an error on git_repo_url' do
+          subject.valid?
+          expect(subject.errors[:git_repo_url]).to_not be_empty
+        end
+      end
+
+      context 'that is not a parsable URI' do
+        let(:git_repo_url) { 'this is not a uri' }
+
+        it 'adds an error on git_repo_url' do
+          subject.valid?
+          expect(subject.errors[:git_repo_url]).to_not be_empty
+        end
+      end
+
+      context 'that is just a file path' do
+        let(:git_repo_url) { '/my/file/path' }
+
+        it 'adds an error on git_repo_url' do
+          subject.valid?
+          expect(subject.errors[:git_repo_url]).to_not be_empty
+        end
+      end
+
+      context 'that is a valid file: uri' do
+        let(:git_repo_url) { 'file:/my/file/path' }
+
+        it 'does not add an error on git_repo_url' do
+          subject.valid?
+          expect(subject.errors[:git_repo_url]).to be_empty
+        end
+      end
+
+      context 'that is a valid git: uri' do
+        let(:git_repo_url) { 'git@github.com:ministryofjustice/fb-sample-json.git' }
+
+        it 'adds an error on git_repo_url' do
+          subject.valid?
+          expect(subject.errors[:git_repo_url]).to_not be_empty
+        end
+      end
+
+      context 'that is a valid https: uri' do
+        let(:git_repo_url) { 'https://my/https/repo.git' }
+
+        it 'does not add an error on git_repo_url' do
+          subject.valid?
+          expect(subject.errors[:git_repo_url]).to be_empty
+        end
+      end
+    end
   end
 
   describe '#to_param' do


### PR DESCRIPTION
We discovered (_during_ Show The Thing!) that when deployed anywhere other than a developers laptop, Publisher can't clone SSH-scheme git repos even if they are public
(see https://stackoverflow.com/a/46993922 for a good discussion as to why)

This PR enforces the use of https URLs (which is recommended by Github)

![screen shot 2018-07-13 at 11 40 07](https://user-images.githubusercontent.com/134501/42687715-8888a632-8691-11e8-9832-a848a5459933.png)
