### PR TITLE
Job logging service

### DIFF
--- a/app/assets/javascripts/services.js
+++ b/app/assets/javascripts/services.js
@@ -4,7 +4,7 @@ function attachEvents() {
   // be more specific
   $( document ).on('ajax:success','.button_to', handleAjaxResponse)
 
-  if( $('tr[data-refreshable]').size() > 0 ) {
+  if( $('*[data-refreshable]').size() > 0 ) {
     set_refresh_timer(5000);
   }
 }
@@ -16,9 +16,7 @@ function set_refresh_timer(interval) {
 }
 
 function refresh_all(refresh_again_interval) {
-  $('tr[data-refreshable]').each( function(i, elem){
-    console.log("elem = ");
-    console.log(elem)
+  $('*[data-refreshable]').each( function(i, elem){
     $.ajax({
           url: $(elem).data('refreshable'),
           cache: false,

--- a/app/assets/stylesheets/deployments.scss
+++ b/app/assets/stylesheets/deployments.scss
@@ -19,6 +19,7 @@
   color: $black;
   font-family: 'Courier New', Console, fixed-width;
   font-size: 80%;
+  min-height: 10em;
   max-width: 100%;
   padding: 0.5em;
   overflow-x: auto;

--- a/app/assets/stylesheets/deployments.scss
+++ b/app/assets/stylesheets/deployments.scss
@@ -12,3 +12,14 @@
 .status-queued {
   background-color: $secondary-text-colour;
 }
+
+.console {
+  background-color: $grey-4;
+  border: 1px inset $border-colour;
+  color: $black;
+  font-family: 'Courier New', Console, fixed-width;
+  font-size: 80%;
+  max-width: 100%;
+  padding: 0.5em;
+  overflow-x: auto;
+}

--- a/app/controllers/services/deployments_controller.rb
+++ b/app/controllers/services/deployments_controller.rb
@@ -5,7 +5,7 @@ class Services::DeploymentsController < ApplicationController
   include Concerns::NestedResourceController
   nest_under :service, attr_name: :slug, param_name: :service_slug
 
-  before_action :load_and_authorize_resource!, only: [:edit, :update, :destroy, :show]
+  before_action :load_and_authorize_resource!, only: [:edit, :update, :destroy, :show, :log]
 
   def index
     params[:per_page] ||= 10
@@ -73,6 +73,18 @@ class Services::DeploymentsController < ApplicationController
       render partial: 'deployment', locals: {deployment: @deployment}
     else
       # default
+    end
+  end
+
+  def log
+    @log_entries = JobLogService.entries(
+      tag: DeployServiceJob.log_tag(@deployment.id),
+      min_timestamp: params[:min_timestamp]
+    )
+    if request.xhr?
+      render partial: 'log_entries', locals: {log_entries: @log_entries}
+    else
+      @environments = ServiceEnvironment.all
     end
   end
 

--- a/app/policies/service_deployment_policy.rb
+++ b/app/policies/service_deployment_policy.rb
@@ -11,6 +11,10 @@ class ServiceDeploymentPolicy < ApplicationPolicy
     policy_for(record.service).show?
   end
 
+  def log?
+    policy_for(record.service).show?
+  end
+
   def edit?
     policy_for(record.service).update?
   end

--- a/app/services/file_log_adapter.rb
+++ b/app/services/file_log_adapter.rb
@@ -1,16 +1,9 @@
 class FileLogAdapter
-  def self.log(message:, job_class:, job_id:, tag:, in_log:)
-    msg = JobLogFormatter.format(
-      message: message,
-      job_id: job_id,
-      job_class: job_class,
-      tag: tag,
-      timestamp: Time.now
-    )
+  def self.log(message:, job_id:, tag:, in_log:)
     log = file_path(in_log)
     FileUtils.mkdir_p(log_dir) unless File.exists?(log_dir)
     File.open(log, 'a') do |f|
-      f << msg + "\n"
+      f << message + "\n"
     end
   end
 

--- a/app/services/file_log_adapter.rb
+++ b/app/services/file_log_adapter.rb
@@ -1,0 +1,88 @@
+class FileLogAdapter
+  def self.log(message:, job_class:, job_id:, tag:, in_log:)
+    msg = JobLogFormatter.format(
+      message: message,
+      job_id: job_id,
+      job_class: job_class,
+      tag: tag,
+      timestamp: Time.now
+    )
+    log = file_path(in_log)
+    FileUtils.mkdir_p(log_dir) unless File.exists?(log_dir)
+    File.open(log, 'a') do |f|
+      f << msg + "\n"
+    end
+  end
+
+  def self.entries(job_id: nil, tag: nil, min_timestamp: nil)
+    entries = []
+    files_matching(job_id: job_id, tag: tag, min_timestamp: min_timestamp).each do |file|
+      entries += all_entries_in_log_matching(
+        filename: file,
+        job_id: job_id,
+        tag: tag,
+        min_timestamp: min_timestamp
+      )
+    end
+
+    entries.compact.flatten.sort_by { |e| e['timestamp'] }
+  end
+
+  def self.all_entries_in_log(log: nil, filename: nil)
+    filename ||= file_path(log)
+    file_entries = File.open(filename, 'r') do |f|
+      f.readlines.map {|line| JSON.parse(line)  rescue nil}
+    end
+  end
+
+  def self.all_entries_in_log_matching(log: nil, filename: nil, job_id: nil, tag: nil, min_timestamp: nil)
+    all_entries_in_log(log: log, filename: filename).select do |obj|
+      entry_matches?(entry: obj, job_id: job_id, tag: tag, min_timestamp: min_timestamp)
+    end
+  end
+
+  def self.purge_logs(max_timestamp:)
+    files_matching(max_timestamp: max_timestamp).each do |f|
+      File.delete(f)
+    end
+  end
+
+  private
+
+  def self.file_matches?(file:, job_id: nil, tag: nil, min_timestamp: nil, max_timestamp: nil)
+    return false unless file
+    return false if job_id && file =~ /job_#{job_id}/
+    return false if tag && file =~ /tag_#{tag}/
+    return false if min_timestamp && File.mtime(file).to_i < min_timestamp
+    return false if max_timestamp && File.mtime(file).to_i > max_timestamp
+    true
+  end
+
+  def self.files_matching(job_id: nil, tag: nil, min_timestamp: nil, max_timestamp: nil)
+    files = Dir.glob(log_dir + '/**.txt')
+    entries = []
+    files.select do |file|
+      file_matches?(file: file, job_id: nil, tag: nil, min_timestamp: nil, max_timestamp: max_timestamp)
+    end
+  end
+
+  def self.entry_matches?(entry:, job_id: nil, tag: nil, min_timestamp: nil)
+    return false unless entry
+    return false if job_id && entry['job_id'] != job_id
+    return false if tag && entry['tag'] != tag
+    return false if min_timestamp && entry['timestamp'] < min_timestamp
+    true
+  end
+
+  def self.file_name(job_id:, tag:)
+    ['job', job_id, 'tag', tag].join('_')
+  end
+
+  def self.file_path(in_log)
+    File.join(log_dir, in_log) + '.txt'
+  end
+
+  def self.log_dir
+    File.join(Rails.root, 'log', 'jobs')
+  end
+end

--- a/app/services/job_log_formatter.rb
+++ b/app/services/job_log_formatter.rb
@@ -1,15 +1,14 @@
 class JobLogFormatter
   def self.format(
     message:,
-    job_class:,
-    job_id:,
+    job:,
     tag:,
     timestamp: Time.now
   )
     line = {
       timestamp: timestamp.to_i,
-      job_class: job_class,
-      job_id: job_id,
+      job_class: job.class.name,
+      job_id: job.job_id,
       tag: tag,
       message: message
     }.to_json

--- a/app/services/job_log_formatter.rb
+++ b/app/services/job_log_formatter.rb
@@ -1,0 +1,17 @@
+class JobLogFormatter
+  def self.format(
+    message:,
+    job_class:,
+    job_id:,
+    tag:,
+    timestamp: Time.now
+  )
+    line = {
+      timestamp: timestamp.to_i,
+      job_class: job_class,
+      job_id: job_id,
+      tag: tag,
+      message: message
+    }.to_json
+  end
+end

--- a/app/services/job_log_service.rb
+++ b/app/services/job_log_service.rb
@@ -2,21 +2,20 @@ class JobLogService
   def self.log(message:, job:, tag: nil)
     formatted_message = JobLogFormatter.format(
       message: message,
-      job_id: job.job_id,
-      job_class: job.class.name,
+      job: job,
       tag: tag,
-      timestamp: Time.now
+      timestamp: Time.current
     )
     adapter.log(
       message: formatted_message,
       job_id: job.job_id,
-      in_log: log_name(job_class: job.class.name, job_id: job.job_id, tag: tag),
+      in_log: log_name(job: job, tag: tag),
       tag: tag
     )
   end
 
   def self.entries(tag: nil, job_id: nil, min_timestamp: nil)
-    raise ArgumentError("You must supply at least one of tag: or job_id:") if tag.nil? && job_id.nil?
+    raise ArgumentError.new("You must supply at least one of tag: or job_id:") if tag.nil? && job_id.nil?
     adapter.entries(job_id: job_id, tag: tag, min_timestamp: min_timestamp)
   end
 
@@ -30,7 +29,7 @@ class JobLogService
     Rails.configuration.x.job_log_adapter
   end
 
-  def self.log_name(job_id:, job_class:, tag:)
-    [job_class, job_id, 'tag', tag].join('_')
+  def self.log_name(job:, tag:)
+    [job.class.name, job.job_id, 'tag', tag].join('_')
   end
 end

--- a/app/services/job_log_service.rb
+++ b/app/services/job_log_service.rb
@@ -1,0 +1,30 @@
+class JobLogService
+  def self.log(message:, job:, tag: nil)
+    adapter.log(
+      message: message,
+      job_id: job.job_id,
+      job_class: job.class.name,
+      in_log: log_name(job_class: job.class.name, job_id: job.job_id, tag: tag),
+      tag: tag
+    )
+  end
+
+  def self.entries(tag: nil, job_id: nil, min_timestamp: nil)
+    raise ArgumentError("You must supply at least one of tag: or job_id:") if tag.nil? && job_id.nil?
+    adapter.entries(job_id: job_id, tag: tag, min_timestamp: min_timestamp)
+  end
+
+  def self.tag_for(job)
+    [job.class.name, job.job_id].join(':')
+  end
+
+  private
+
+  def self.adapter
+    Rails.configuration.x.job_log_adapter
+  end
+
+  def self.log_name(job_id:, job_class:, tag:)
+    [job_class, job_id, 'tag', tag].join('_')
+  end
+end

--- a/app/services/job_log_service.rb
+++ b/app/services/job_log_service.rb
@@ -1,9 +1,15 @@
 class JobLogService
   def self.log(message:, job:, tag: nil)
-    adapter.log(
+    formatted_message = JobLogFormatter.format(
       message: message,
       job_id: job.job_id,
       job_class: job.class.name,
+      tag: tag,
+      timestamp: Time.now
+    )
+    adapter.log(
+      message: formatted_message,
+      job_id: job.job_id,
       in_log: log_name(job_class: job.class.name, job_id: job.job_id, tag: tag),
       tag: tag
     )

--- a/app/services/redis_log_adapter.rb
+++ b/app/services/redis_log_adapter.rb
@@ -1,0 +1,80 @@
+class RedisLogAdapter
+  def self.log(message:, job_id:, tag:, in_log:)
+    byebug
+    connection.append(
+      key_for(job_id: job_id, tag: tag),
+      message + "\n"
+    )
+  end
+
+  def self.entries(job_id: nil, tag: nil, min_timestamp: nil)
+    entries = []
+    keys_matching(job_id: job_id, tag: tag, min_timestamp: min_timestamp).each do |key|
+      entries += all_entries_in_log_matching(
+        key: key,
+        job_id: job_id,
+        tag: tag,
+        min_timestamp: min_timestamp
+      )
+    end
+
+    entries.compact.flatten.sort_by { |e| e['timestamp'] }
+  end
+
+  def self.all_entries_in_log(log: nil, key: nil)
+    key ||= log
+    entries = connection.get(key).split("\n").map {|line| JSON.parse(line)  rescue nil}
+  end
+
+  def self.all_entries_in_log_matching(log: nil, key: nil, job_id: nil, tag: nil, min_timestamp: nil)
+    all_entries_in_log(log: log, key: key).select do |obj|
+      entry_matches?(entry: obj, job_id: job_id, tag: tag, min_timestamp: min_timestamp)
+    end
+  end
+
+  def self.purge_logs(max_timestamp:)
+    keys_matching(max_timestamp: max_timestamp).each do |f|
+      File.delete(f)
+    end
+  end
+
+  private
+
+  def self.connection
+    Rails.configuration.x.job_log_redis
+  end
+
+  def self.key_matches?(key:, job_id: nil, tag: nil, min_timestamp: nil, max_timestamp: nil)
+    return false unless key
+    return false if job_id && key =~ /job_#{job_id}/
+    return false if tag && key =~ /tag_#{tag}/
+    # Not supported on Redis
+    # return false if min_timestamp && File.mtime(key).to_i < min_timestamp
+    # return false if max_timestamp && File.mtime(key).to_i > max_timestamp
+    true
+  end
+
+  def self.keys_matching(job_id: nil, tag: nil, min_timestamp: nil, max_timestamp: nil)
+    keys = connection.keys(pattern = "*job_*")
+    entries = []
+    keys.select do |key|
+      key_matches?(key: key, job_id: nil, tag: nil, min_timestamp: nil, max_timestamp: max_timestamp)
+    end
+  end
+
+  def self.entry_matches?(entry:, job_id: nil, tag: nil, min_timestamp: nil)
+    return false unless entry
+    return false if job_id && entry['job_id'] != job_id
+    return false if tag && entry['tag'] != tag
+    return false if min_timestamp && entry['timestamp'] < min_timestamp
+    true
+  end
+
+  def self.key_for(job_id:, tag:)
+    ['job', job_id, 'tag', tag].join('_')
+  end
+
+  def self.log_dir
+    File.join(Rails.root, 'log', 'jobs')
+  end
+end

--- a/app/services/redis_log_adapter.rb
+++ b/app/services/redis_log_adapter.rb
@@ -1,6 +1,5 @@
 class RedisLogAdapter
   def self.log(message:, job_id:, tag:, in_log:)
-    byebug
     connection.append(
       key_for(job_id: job_id, tag: tag),
       message + "\n"

--- a/app/views/services/deployments/_deployment.html.haml
+++ b/app/views/services/deployments/_deployment.html.haml
@@ -20,4 +20,4 @@
     - else
       = deployment.created_by_user.name
   %td
-    = link_to t('.view_log'), service_deployment_path(@service, deployment)
+    = link_to t('.view_log'), log_service_deployment_path(@service, deployment)

--- a/app/views/services/deployments/_environments_nav.html.haml
+++ b/app/views/services/deployments/_environments_nav.html.haml
@@ -1,0 +1,13 @@
+.inline-nav
+  %ul
+    %li
+      = t '.environments'
+    - @environments.each do |env|
+      %li
+        - if current_env == env.slug.to_s
+          %span
+            = env.name
+        - else
+          = link_to env.name, {env: env.slug}
+    %li
+      = link_to t('.all_envs_status'), status_service_deployments_path(@service)

--- a/app/views/services/deployments/_log_entries.html.haml
+++ b/app/views/services/deployments/_log_entries.html.haml
@@ -1,0 +1,6 @@
+- if @log_entries.empty?
+  %em{ class: 'console', id: 'log-entries', data: { refreshable: log_service_deployment_path(@service, @deployment) } }
+    = t('.no_log_entries')
+- else
+  %pre{ class: 'console', id: 'log-entries', data: { refreshable: log_service_deployment_path(@service, @deployment) } }
+    = render partial: 'log_entry', collection: @log_entries

--- a/app/views/services/deployments/_log_entry.html.haml
+++ b/app/views/services/deployments/_log_entry.html.haml
@@ -1,0 +1,1 @@
+= [Time.at(log_entry['timestamp']).to_s(:iso8601), log_entry['message']].join("\t")

--- a/app/views/services/deployments/index.html.haml
+++ b/app/views/services/deployments/index.html.haml
@@ -1,19 +1,6 @@
 = render partial: 'services/header', locals: {service: @service}
 
-
-.inline-nav
-  %ul
-    %li
-      = t '.environments'
-    - @environments.each do |env|
-      %li
-        - if params[:env] == env.slug.to_s
-          %span
-            = env.name
-        - else
-          = link_to env.name, {env: env.slug}
-    %li
-      = link_to t('.all_envs_status'), status_service_deployments_path(@service)
+= render partial: 'environments_nav', locals: {current_env: params[:env]}
 
 %table#deployments
   %thead

--- a/app/views/services/deployments/log.html.haml
+++ b/app/views/services/deployments/log.html.haml
@@ -1,0 +1,8 @@
+= render partial: 'services/header', locals: {service: @service}
+
+%p.lede
+  = t '.lede_html', deployment_id: @deployment.id
+
+= render partial: 'environments_nav', locals: {current_env: @deployment.environment_slug}
+
+= render partial: 'log_entries', locals: {log_entries: @log_entries}

--- a/config/initializers/job_log.rb
+++ b/config/initializers/job_log.rb
@@ -1,0 +1,10 @@
+
+if ['production', 'staging'].include?(ENV['RAILS_ENV'])
+  job_log_adapter = RedisLogAdapter
+  uri = uri = URI.parse (ENV["REDISCLOUD_URL"] || ENV['REDIS_URL'])
+  job_log_adapter.redis = Redis.new(host:uri.host, port:uri.port, password:uri.password)
+else
+  job_log_adapter = FileLogAdapter
+end
+
+Rails.configuration.x.job_log_adapter = job_log_adapter

--- a/config/initializers/job_log.rb
+++ b/config/initializers/job_log.rb
@@ -1,10 +1,8 @@
 
-if ['production', 'staging'].include?(ENV['RAILS_ENV'])
+if uri = URI.parse(ENV["REDISCLOUD_URL"] || ENV['REDIS_URL'])
   job_log_adapter = RedisLogAdapter
-  uri = uri = URI.parse (ENV["REDISCLOUD_URL"] || ENV['REDIS_URL'])
-  job_log_adapter.redis = Redis.new(host:uri.host, port:uri.port, password:uri.password)
+  Rails.configuration.x.job_log_redis = Redis.new(host:uri.host, port:uri.port, password:uri.password)
+  Rails.configuration.x.job_log_adapter = job_log_adapter
 else
-  job_log_adapter = FileLogAdapter
+  Rails.configuration.x.job_log_adapter = FileLogAdapter
 end
-
-Rails.configuration.x.job_log_adapter = job_log_adapter

--- a/config/initializers/job_log.rb
+++ b/config/initializers/job_log.rb
@@ -1,13 +1,13 @@
 url = ENV["REDISCLOUD_URL"] || ENV['REDIS_URL']
+job_log_adapter_class = FileLogAdapter
 if url.present?
   begin
     uri = URI.parse(url)
-    job_log_adapter = RedisLogAdapter
     Rails.configuration.x.job_log_redis = Redis.new(host:uri.host, port:uri.port, password:uri.password)
-    Rails.configuration.x.job_log_adapter = job_log_adapter
+    job_log_adapter_class = RedisLogAdapter
   rescue URI::InvalidURIError
     puts "could not parse a valid Redis URI from #{url} - falling back to file log"
   end
 end
 
-Rails.configuration.x.job_log_adapter ||= FileLogAdapter
+Rails.configuration.x.job_log_adapter = job_log_adapter_class

--- a/config/initializers/job_log.rb
+++ b/config/initializers/job_log.rb
@@ -1,8 +1,13 @@
-
-if uri = URI.parse(ENV["REDISCLOUD_URL"] || ENV['REDIS_URL'])
-  job_log_adapter = RedisLogAdapter
-  Rails.configuration.x.job_log_redis = Redis.new(host:uri.host, port:uri.port, password:uri.password)
-  Rails.configuration.x.job_log_adapter = job_log_adapter
-else
-  Rails.configuration.x.job_log_adapter = FileLogAdapter
+url = ENV["REDISCLOUD_URL"] || ENV['REDIS_URL']
+if url.present?
+  begin
+    uri = URI.parse(url)
+    job_log_adapter = RedisLogAdapter
+    Rails.configuration.x.job_log_redis = Redis.new(host:uri.host, port:uri.port, password:uri.password)
+    Rails.configuration.x.job_log_adapter = job_log_adapter
+  rescue URI::InvalidURIError
+    puts "could not parse a valid Redis URI from #{url} - falling back to file log"
+  end
 end
+
+Rails.configuration.x.job_log_adapter ||= FileLogAdapter

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,3 @@
-if ENV["REDISCLOUD_URL"]
-  $redis = Redis.new(:url => ENV["REDISCLOUD_URL"])
+if url = (ENV["REDISCLOUD_URL"] || ENV["REDIS_URL"])
+  $redis = Redis.new(:url => url)
 end

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,6 +1,6 @@
 # Establish a connection between Resque and Redis
 if Rails.env.production? || Rails.env.staging?
-  uri = URI.parse ENV["REDISCLOUD_URL"]
+  uri = URI.parse (ENV["REDISCLOUD_URL"] || ENV['REDIS_URL'])
   Resque.redis = Redis.new host:uri.host, port:uri.port, password:uri.password
 else
   # conf for your localhost

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,14 @@ en:
   auth:
     existing_user:
       welcome_html: "Welcome back, <strong>%{user_name}</strong>!"
+  deploy_service_job:
+    all_done: 'ALL DONE'
+    complete: 'Finished - writing status back to Deployment'
+    configuring_params: 'Updating config params'
+    deploying_service: 'Deploying service'
+    reading_commit: 'Reading commit SHA'
+    starting: 'Starting job %{job_id} for ServiceDeployment %{service_deployment_id}'
+    writing_commit: 'Writing commit SHA %{sha}'
   home:
     login:
       link_text: Use your MoJ Google Account to sign in or sign up
@@ -123,12 +131,16 @@ en:
       update:
         success: Config Param '%{name}' (%{environment}) updated successfully
     deployments:
-      index:
+      environments_nav:
         all_envs_status: '(all)'
+        environments: 'Deployments in'
+      index:
         completed_at: Finished at
         created_at: Job created at
-        environments: 'Deployments in'
         status: 'Status'
+      log:
+        lede_html: "Deployment log"
+        no_log_entries: '(no log entries)'
       new:
         heading: Deploy '%{service}' to %{environment}
         lede_html:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       resources :deployments, controller_name: :service_deployments do
         get 'status', on: :collection, to: 'deployments#status'
         get '(/:env)', on: :collection, to: 'deployments#index', constraints: ServiceEnvironment::RoutingConstraint.new
+        get 'log', on: :member, to: 'deployments#log'
       end
     end
   end

--- a/spec/jobs/deploy_service_job_spec.rb
+++ b/spec/jobs/deploy_service_job_spec.rb
@@ -14,6 +14,7 @@ describe DeployServiceJob do
   end
 
   before do
+    allow(JobLogService).to receive(:log)
     allow(ServiceDeployment).to receive(:find).with('my-deployment-id').and_return(deployment)
     allow(deployment).to receive(:update_status)
     allow(deployment).to receive(:update_attributes)

--- a/spec/services/job_log_formatter_spec.rb
+++ b/spec/services/job_log_formatter_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe JobLogFormatter do
+  describe '.format' do
+    describe 'return value' do
+      let(:job) { DeployServiceJob.new }
+      let(:timestamp) { Time.now }
+      let(:return_value) do
+        described_class.format(
+          message: 'my message',
+          job: job,
+          tag: 'my-tag',
+          timestamp: timestamp
+        )
+      end
+
+      it 'is a hash serialised to JSON' do
+        expect(JSON.parse(return_value)).to eq(
+          {
+            'timestamp' => timestamp.to_i,
+            'tag' => 'my-tag',
+            'message' => 'my message',
+            'job_class' => 'DeployServiceJob',
+            'job_id' => job.job_id
+          }
+        )
+
+      end
+    end
+  end
+end

--- a/spec/services/job_log_service_spec.rb
+++ b/spec/services/job_log_service_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+require 'support/time_helpers'
+
+describe JobLogService do
+  let(:job) { DeployServiceJob.new }
+  let(:tag) { 'my-tag' }
+
+  describe '.tag_for' do
+    context 'given a job' do
+      it 'returns the class & id separated by ":"' do
+        expect(described_class.tag_for(job)).to eq("DeployServiceJob:#{job.job_id}")
+      end
+    end
+  end
+
+  describe '.entries' do
+    let(:adapter) { described_class.send(:adapter) }
+    let(:adapter_entries) { ['adapter', 'entries'] }
+    let(:min_timestamp) { 1.day.ago.to_i }
+    before do
+      allow(adapter).to receive(:entries).and_return(adapter_entries)
+    end
+
+    context 'when there is no tag or job_id' do
+      it 'raises an ArgumentError' do
+        expect { described_class.entries(min_timestamp: min_timestamp) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'given a tag' do
+      it 'calls entries on the adapter, passing all arguments along' do
+        expect(adapter).to receive(:entries).with(hash_including(tag: tag))
+        described_class.entries(tag: tag)
+      end
+
+      it 'returns the result of adapter.entries' do
+        expect( described_class.entries(tag: tag) ).to eq(adapter_entries)
+      end
+    end
+  end
+
+  describe '.log_name' do
+    context 'given a job and a tag' do
+      it 'returns (job_class)_(job_id)_tag_(tag)' do
+        expect(described_class.send(:log_name, job: job, tag: tag)).to eq("DeployServiceJob_#{job.job_id}_tag_my-tag")
+      end
+    end
+  end
+
+  describe '.log' do
+    before do
+      allow(JobLogFormatter).to receive(:format).and_return "formatted message"
+      allow(described_class.adapter).to receive(:log)
+      allow(described_class).to receive(:log_name).and_return 'my-log-name'
+    end
+    context 'given a message, tag, and job' do
+      let(:message) { 'given message' }
+      let!(:now) { Time.current.change(usec: 0) }
+
+      it 'asks JobLogFormatter to format the message with the current timestamp' do
+        expect(JobLogFormatter).to receive(:format).with(
+          job: job,
+          tag: tag,
+          message: message,
+          timestamp: now
+        ).and_return "formatted message"
+        travel_to(now) do
+          described_class.log( tag: tag, job: job, message: message )
+        end
+      end
+
+      it 'asks the adapter to log the formatted message, passing the right arguments' do
+        expect(described_class.adapter).to receive(:log).with(
+          message: 'formatted message',
+          job_id: job.job_id,
+          tag: tag,
+          in_log: 'my-log-name'
+        )
+        described_class.log( tag: tag, job: job, message: message )
+      end
+    end
+  end
+end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
Actually provide the interface behind the 'View Log' link on deployments.

Add a JobLoggingService with two adapters - FileLogAdapter for local development, and RedisLogAdapter. If there is an environment variable set for REDISCLOUD_URL or REDIS_URL it will use the redis adapter, otherwise file log.
<img width="1102" alt="screen shot 2018-07-19 at 11 46 42" src="https://user-images.githubusercontent.com/134501/42938222-715c297c-8b49-11e8-9038-4d74d392f748.png">
