### PR TITLE
force a restart when deploying by deleting pods

### DIFF
--- a/app/jobs/deploy_service_job.rb
+++ b/app/jobs/deploy_service_job.rb
@@ -36,6 +36,12 @@ class DeployServiceJob < ApplicationJob
       deployment: @deployment
     )
 
+    log_for_user(:restarting)
+    DeploymentService.restart_service(
+      environment_slug: @deployment.environment_slug,
+      service: @deployment.service
+    )
+
     log_for_user(:complete)
     @deployment.complete!
 

--- a/app/services/cloud_platform_adapter.rb
+++ b/app/services/cloud_platform_adapter.rb
@@ -187,4 +187,13 @@ class CloudPlatformAdapter
     end
   end
 
+  def self.delete_pods(environment_slug:, service: service)
+    environment = ServiceEnvironment.find(environment_slug)
+    KubernetesAdapter.delete_pods(
+      label: "run=#{service.slug}",
+      namespace: environment.namespace,
+      context: environment.kubectl_context
+    )
+  end
+
 end

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -157,6 +157,17 @@ class DeploymentService
     )
   end
 
+  def self.restart_service(service:, environment_slug:)
+    adapter = adapter_for(environment_slug)
+    # The deployment will detect that the pods have been
+    # deleted, and instantly begin creating new ones
+    # that will pick up any new config maps or json
+    adapter.delete_pods(
+      environment_slug: environment_slug,
+      service: service
+    )
+  end
+
   def self.url_for(environment_slug:, service:)
     adapter = adapter_for(environment_slug)
     begin

--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -320,6 +320,17 @@ class KubernetesAdapter
     )
   end
 
+  def self.delete_pods( label:, namespace:, context: )
+    ShellAdapter.exec(
+      kubectl_binary,
+      'delete',
+      'pods',
+      '-l',
+      label,
+      std_args(namespace: namespace, context: context)
+    )
+  end
+
   private
 
   def self.std_args(namespace:, context:)

--- a/app/services/minikube_adapter.rb
+++ b/app/services/minikube_adapter.rb
@@ -162,6 +162,15 @@ class MinikubeAdapter
     end
   end
 
+  def self.delete_pods(environment_slug:, service: service)
+    environment = ServiceEnvironment.find(environment_slug)
+    KubernetesAdapter.delete_pods(
+      label: "run=#{service.slug}",
+      namespace: environment.namespace,
+      context: environment.kubectl_context
+    )
+  end
+
   private
 
   def self.default_private_key_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
     configuring_params: 'Updating config params'
     deploying_service: 'Deploying service'
     reading_commit: 'Reading commit SHA'
+    restarting: 'Restarting service'
     starting: 'Starting job %{job_id} for ServiceDeployment %{service_deployment_id}'
     writing_commit: 'Writing commit SHA %{sha}'
   home:

--- a/spec/jobs/deploy_service_job_spec.rb
+++ b/spec/jobs/deploy_service_job_spec.rb
@@ -22,6 +22,7 @@ describe DeployServiceJob do
     allow(VersionControlService).to receive(:checkout).and_return('some-sha')
     allow(DeploymentService).to receive(:setup_service).and_return('setup_service-result')
     allow(DeploymentService).to receive(:configure_env_vars).and_return('configure_env_vars-result')
+    allow(DeploymentService).to receive(:restart_service).and_return('restart_service-result')
   end
 
   describe '#perform' do
@@ -111,6 +112,14 @@ describe DeployServiceJob do
 
     it 'updates the deployment with the returned commit sha' do
       expect(deployment).to receive(:update_attributes).with(commit_sha: 'some-sha')
+      perform
+    end
+
+    it 'restarts the service' do
+      allow(DeploymentService).to receive(:restart_service).with(
+        service: service,
+        environment_slug: 'myenv'
+      )
       perform
     end
   end


### PR DESCRIPTION
When a user updates a config param then deploys, or deploys a different sub-directory of the same commit, kubernetes thinks there is nothing to do, so leaves the existing containers running and the changes have no effect.

This PR forces an update at the end of each DeployServiceJob by deleting the pods. The Kubernetes Deployment abstraction will then immediately recreate new pods to meet its declared minimum number - and these new pods will pick up the new JSON and/or configmap