### PR TITLE
allow CORS to fix cloudfront requests showing up as cancelled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,11 @@ gem 'puma', '~> 3.11'
 # Policy-based authorization
 gem 'pundit'
 
+# allow Cross-origin requests, otherwise CDN cache-fetch requests show up
+# as cancelled, even though they work when you copy-and-paste the URL into
+# a browser
+gem 'rack-cors', require: 'rack/cors'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
+    rack-cors (1.0.2)
     rack-protection (2.0.3)
       rack
     rack-test (1.0.0)
@@ -359,6 +360,7 @@ DEPENDENCIES
   poltergeist
   puma (~> 3.11)
   pundit
+  rack-cors
   rails (~> 5.2.0)
   resque
   rspec (~> 3.6.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,12 @@ module FbPublisher
     logger.formatter = config.log_formatter
     config.log_tags  = [:subdomain, :uuid]
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins 'localhost:3000', /https*:\/\/.*?bloopist\.com/
+        resource '*', :headers => :any, :methods => :any
+      end
+    end
   end
 end


### PR DESCRIPTION
When serving static assets from cloudfront, secondary requests for resources specified from within those static assets show up as 'cancelled' in the chrome console, even though they work fine when you copy and paste their URL into a browser.

This is because Rails by default does not allow Cross-origin requests, you must specifically [enable them](https://blog.kurttomlinson.com/posts/how-to-fix-access-control-allow-origin-error-in-ruby-on-rails). 

This PR adds the rack-cors gem + config to enable it.