### PR TITLE
Display pagination for Deployment History

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem 'jquery-rails'
 gem 'omniauth' #, '~> 1.6.1'
 gem 'omniauth-auth0', '~> 2.0.0'
 
+# Pagination
+gem 'pagy'
+
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
     omniauth-oauth2 (1.5.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.2)
+    pagy (0.19.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
@@ -355,6 +356,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   omniauth
   omniauth-auth0 (~> 2.0.0)
+  pagy
   pg (>= 0.18, < 2.0)
   phantomjs
   poltergeist
@@ -380,4 +382,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/app/controllers/services/deployments_controller.rb
+++ b/app/controllers/services/deployments_controller.rb
@@ -3,6 +3,7 @@ class Services::DeploymentsController < ApplicationController
   before_action :require_user!
 
   include Concerns::NestedResourceController
+  include Pagy::Backend
   nest_under :service, attr_name: :slug, param_name: :service_slug
 
   before_action :load_and_authorize_resource!, only: [:edit, :update, :destroy, :show, :log]
@@ -14,14 +15,10 @@ class Services::DeploymentsController < ApplicationController
     params[:dir] ||= 'desc'
 
     @environments = ServiceEnvironment.all
-    @deployments = DeploymentService.list(
-      service: @service,
-      environment_slug: params[:env],
-      page: params[:page],
-      per_page: params[:per_page],
-      order: params[:order],
-      dir: params[:dir]
-    )
+    @pagy, @deployments = pagy(ServiceDeployment.where(service: @service,
+                                                       environment_slug: params[:env]).order("#{params[:order]} #{params[:dir]}"),
+                               items: params[:per_page])
+
     @deployment = ServiceDeployment.new(service: @service, environment_slug: params[:env])
   end
 

--- a/app/helpers/deployment_helper.rb
+++ b/app/helpers/deployment_helper.rb
@@ -1,0 +1,3 @@
+module DeploymentHelper
+  include Pagy::Frontend
+end

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -12,16 +12,6 @@ class DeploymentService
                               environment_slug: environment_slug)
   end
 
-  def self.list(service:, environment_slug:, per_page: 10, page: 1, order: 'created_at', dir: 'desc')
-    ServiceDeployment.where(
-      service_id: service.id,
-      environment_slug: environment_slug
-    )
-    .order([order, dir].join(' '))
-    .limit(per_page)
-    .offset( (page-1) * per_page )
-  end
-
   def self.adapter_for(environment_slug)
     environment = ServiceEnvironment.find(environment_slug)
     name = environment.deployment_adapter

--- a/app/views/services/deployments/index.html.haml
+++ b/app/views/services/deployments/index.html.haml
@@ -19,4 +19,5 @@
         = t '.actions'
 
   %tbody
+    = pagy_nav(@pagy).html_safe
     = render partial: 'deployment', collection: @deployments

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,8 @@ en:
         completed_at: Finished at
         created_at: Job created at
         status: 'Status'
+        next: 'Next'
+        previous: 'Previous'
       log:
         lede_html: "Deployment log"
         no_log_entries: '(no log entries)'

--- a/spec/features/deployment_spec.rb
+++ b/spec/features/deployment_spec.rb
@@ -1,0 +1,69 @@
+require 'capybara_helper'
+
+describe 'visiting services/deployment' do
+  context 'as a logged in user' do
+    let(:user) do
+      User.create(id: 'abc123', name: 'test user',
+                  email: 'test@example.justice.gov.uk')
+    end
+
+    let(:service) do
+      Service.create!(id: 'fed456',
+                      name: 'My New Service',
+                      slug: 'my-new-service',
+                      git_repo_url: 'https://github.com/ministryofjustice/fb-sample-json.git',
+                      created_by_user: user)
+    end
+
+    before do
+      login_as!(user)
+    end
+
+    describe '.index', js: true do
+      context 'when there are more than 10 deployments' do
+        before do
+          11.times { create_deployment }
+        end
+
+        it 'enables link to next page if total deployments are greater than 10' do
+          visit "/services/#{service.slug}/deployments?env=dev"
+          expect(page).to have_link('Next')
+        end
+
+        it 'enables link to previous page if not on the first page' do
+          visit "/services/#{service.slug}/deployments?env=dev"
+          click_link('Next')
+          expect(page).to have_link('Prev')
+        end
+      end
+
+      context 'when there are 10 or less deployments' do
+        before do
+          3.times { create_deployment }
+        end
+
+        it 'does not enable link to next page' do
+          visit "/services/#{service.slug}/deployments?env=dev"
+          expect(page).to_not have_link('Next')
+        end
+
+        it 'does not enable link to previous page' do
+          visit "/services/#{service.slug}/deployments?env=dev"
+          expect(page).to_not have_link('Prev')
+        end
+      end
+    end
+
+    def create_deployment
+      ServiceDeployment.create!(commit_sha: 'f7735e5',
+                                environment_slug: 'dev',
+                                created_at: Time.new - 30,
+                                updated_at: Time.new,
+                                created_by_user: user,
+                                service: service,
+                                completed_at: Time.new,
+                                status: 'completed',
+                                json_sub_dir: '')
+    end
+  end
+end

--- a/spec/services/git_adapter_spec.rb
+++ b/spec/services/git_adapter_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 describe GitAdapter do
   before do
+    allow(GitAdapter).to receive(:git_binary).and_return('git')
     allow(ShellAdapter).to receive(:exec)
     allow(ShellAdapter).to receive(:output_of).and_return('cmd output')
-    allow(ShellAdapter).to receive(:output_of).with("which git").and_return('git')
   end
 
   describe '.clone_repo' do


### PR DESCRIPTION
The pagination only allows a maximum of 10 items to be displayed on a page. The page displays a 'Next' and / or 'Previous' link to allow user to navigate through the pages.

No styling has been done for the `Next` or `Previous` links