### PR TITLE
Link the deployed commit sha to go direct to that commit on Github

### DIFF
--- a/app/controllers/services/deployments_controller.rb
+++ b/app/controllers/services/deployments_controller.rb
@@ -66,8 +66,9 @@ class Services::DeploymentsController < ApplicationController
   end
 
   def show
+    @git_url = ServiceDeployment.generate_commit_link(@deployment.service_id, @deployment.commit_sha)
     if request.xhr?
-      render partial: 'deployment', locals: {deployment: @deployment}
+      render partial: 'deployment', locals: {deployment: @deployment, commit_link: @git_url}
     else
       # default
     end

--- a/app/models/service_deployment.rb
+++ b/app/models/service_deployment.rb
@@ -47,6 +47,13 @@ class ServiceDeployment < ActiveRecord::Base
     logger.info "attributes updated to #{attributes}"
   end
 
+  def self.generate_commit_link(service_id, commit_sha)
+    url_link = Service.find(service_id).git_repo_url
+    return if url_link.nil?
+    url_link.slice!('.git')
+    url_link << '/commit/' << commit_sha
+  end
+
   def pending?
     [STATUS[:queued], STATUS[:deploying]].include?(status)
   end

--- a/app/views/services/deployments/_deployment.html.haml
+++ b/app/views/services/deployments/_deployment.html.haml
@@ -10,7 +10,10 @@
     - else
       \-
   %td
-    = deployment.commit_sha
+    - if deployment.commit_sha.present?
+      = link_to deployment.commit_sha, @git_url
+    - else
+      \-
   %td
     %span{ class: ['status', ['status', deployment.status].join('-')].join(' ') }
       = t( deployment.status, scope: [:shared, :service_deployments, :status] )

--- a/spec/features/deployment_spec.rb
+++ b/spec/features/deployment_spec.rb
@@ -1,25 +1,37 @@
 require 'capybara_helper'
 
 describe 'visiting services/deployment' do
+  let(:user) do
+    User.create(id: 'abc123', name: 'test user',
+                email: 'test@example.justice.gov.uk')
+  end
+
+  before do
+    login_as!(user)
+  end
+
   context 'as a logged in user' do
-    let(:user) do
-      User.create(id: 'abc123', name: 'test user',
-                  email: 'test@example.justice.gov.uk')
-    end
-
-    let(:service) do
-      Service.create!(id: 'fed456',
-                      name: 'My New Service',
-                      slug: 'my-new-service',
-                      git_repo_url: 'https://github.com/ministryofjustice/fb-sample-json.git',
-                      created_by_user: user)
-    end
-
-    before do
-      login_as!(user)
-    end
-
     describe '.index', js: true do
+      let(:service) do
+        Service.create!(id: 'fed456',
+                        name: 'My New Service',
+                        slug: 'my-new-service',
+                        git_repo_url: 'https://github.com/ministryofjustice/fb-sample-json.git',
+                        created_by_user: user)
+      end
+
+      def create_deployment
+        ServiceDeployment.create!(commit_sha: 'f7735e5',
+                                  environment_slug: 'dev',
+                                  created_at: Time.new - 30,
+                                  updated_at: Time.new,
+                                  created_by_user: user,
+                                  service: service,
+                                  completed_at: Time.new,
+                                  status: 'completed',
+                                  json_sub_dir: '')
+      end
+
       context 'when there are more than 10 deployments' do
         before do
           11.times { create_deployment }
@@ -54,16 +66,25 @@ describe 'visiting services/deployment' do
       end
     end
 
-    def create_deployment
-      ServiceDeployment.create!(commit_sha: 'f7735e5',
-                                environment_slug: 'dev',
-                                created_at: Time.new - 30,
-                                updated_at: Time.new,
-                                created_by_user: user,
-                                service: service,
-                                completed_at: Time.new,
-                                status: 'completed',
-                                json_sub_dir: '')
+    describe '.show', js: true do
+      context 'when adding a new deployment' do
+        it 'creates a link to the commit sha on Github' do
+          create_service
+          visit '/services/a-different-service/deployments/status'
+          click_link('Deploy Now', match: :first)
+          fill_in('Commit SHA, branch, or tag', with: 'f7735e5')
+          click_button('Deploy now')
+          find_link('f7735e5', wait: 60)
+          expect(page).to have_link(href: 'https://github.com/ministryofjustice/fb-sample-json/commit/f7735e5')
+        end
+      end
+
+      def create_service
+        visit '/services/new'
+        fill_in('Service name', with: 'A Different Service')
+        fill_in('URL of the service config JSON Git repository', with: 'https://github.com/ministryofjustice/fb-sample-json.git')
+        click_button('Next')
+      end
     end
   end
 end


### PR DESCRIPTION
Requirement uncovered from user testing to create a hyperlink from the commit-sha to the actual Github commit when the user creates a new deployment.