### PR TITLE
Link deployed commit sha to go the commit on Github

### DIFF
--- a/app/models/service_deployment.rb
+++ b/app/models/service_deployment.rb
@@ -49,9 +49,10 @@ class ServiceDeployment < ActiveRecord::Base
     [STATUS[:queued], STATUS[:deploying]].include?(status)
   end
 
-  def self.generate_github_link(service:, commit_sha:)
+  def generate_github_link
+    return if service.git_repo_url.blank?
+
     url_link = service.git_repo_url
-    return if url_link.nil?
     url_link.slice!('.git')
     url_link << '/commit/' << commit_sha
   end

--- a/app/models/service_deployment.rb
+++ b/app/models/service_deployment.rb
@@ -18,8 +18,6 @@ class ServiceDeployment < ActiveRecord::Base
 
   validates :status, inclusion: {in: STATUS.values}
 
-
-
   def self.latest(service_id:, environment_slug:)
     where(  service_id: service_id,
             environment_slug: environment_slug)
@@ -49,5 +47,12 @@ class ServiceDeployment < ActiveRecord::Base
 
   def pending?
     [STATUS[:queued], STATUS[:deploying]].include?(status)
+  end
+
+  def self.generate_github_link(service:, commit_sha:)
+    url_link = Service.find(service.id).git_repo_url
+    return if url_link.nil?
+    url_link.slice!('.git')
+    url_link << '/commit/' << commit_sha
   end
 end

--- a/app/models/service_deployment.rb
+++ b/app/models/service_deployment.rb
@@ -50,7 +50,7 @@ class ServiceDeployment < ActiveRecord::Base
   end
 
   def self.generate_github_link(service:, commit_sha:)
-    url_link = Service.find(service.id).git_repo_url
+    url_link = service.git_repo_url
     return if url_link.nil?
     url_link.slice!('.git')
     url_link << '/commit/' << commit_sha

--- a/app/views/services/deployments/_deployment.html.haml
+++ b/app/views/services/deployments/_deployment.html.haml
@@ -11,8 +11,7 @@
       \-
   %td
     - if deployment.commit_sha.present?
-      = link_to(deployment.commit_sha, ServiceDeployment.generate_github_link(service: deployment.service,
-                                                                              commit_sha: deployment.commit_sha))
+      = link_to(deployment.commit_sha, deployment.generate_github_link)
     - else
       \-
   %td

--- a/app/views/services/deployments/_deployment.html.haml
+++ b/app/views/services/deployments/_deployment.html.haml
@@ -10,7 +10,11 @@
     - else
       \-
   %td
-    = deployment.commit_sha
+    - if deployment.commit_sha.present?
+      = link_to(deployment.commit_sha, ServiceDeployment.generate_github_link(service: deployment.service,
+                                                                               commit_sha: deployment.commit_sha))
+    - else
+      \-
   %td
     %span{ class: ['status', ['status', deployment.status].join('-')].join(' ') }
       = t( deployment.status, scope: [:shared, :service_deployments, :status] )

--- a/app/views/services/deployments/_deployment.html.haml
+++ b/app/views/services/deployments/_deployment.html.haml
@@ -12,7 +12,7 @@
   %td
     - if deployment.commit_sha.present?
       = link_to(deployment.commit_sha, ServiceDeployment.generate_github_link(service: deployment.service,
-                                                                               commit_sha: deployment.commit_sha))
+                                                                              commit_sha: deployment.commit_sha))
     - else
       \-
   %td

--- a/app/views/services/deployments/_environment.html.haml
+++ b/app/views/services/deployments/_environment.html.haml
@@ -3,8 +3,7 @@
     = ServiceEnvironment.find(environment.environment_slug).name
   %td
     - if environment.commit_sha.present?
-      = link_to(environment.commit_sha, ServiceDeployment.generate_github_link(service: environment.service,
-                                                                               commit_sha: environment.commit_sha))
+      = link_to(environment.commit_sha, environment.generate_github_link)
     - else
       \-
   %td

--- a/app/views/services/deployments/_environment.html.haml
+++ b/app/views/services/deployments/_environment.html.haml
@@ -3,7 +3,8 @@
     = ServiceEnvironment.find(environment.environment_slug).name
   %td
     - if environment.commit_sha.present?
-      = link_to(environment.commit_sha, environment.commit_sha)
+      = link_to(environment.commit_sha, ServiceDeployment.generate_github_link(service: environment.service,
+                                                                               commit_sha: environment.commit_sha))
     - else
       \-
   %td

--- a/spec/features/deployment_spec.rb
+++ b/spec/features/deployment_spec.rb
@@ -52,6 +52,53 @@ describe 'visiting services/deployment' do
           expect(page).to_not have_link('Prev')
         end
       end
+
+      it 'links deployment commit sha to Github' do
+        create_deployment
+        visit "/services/#{service.slug}/deployments?env=dev"
+        expect(page).to have_link('f7735e5', href: 'https://github.com/ministryofjustice/fb-sample-json/commit/f7735e5')
+      end
+    end
+
+    describe '.status' do
+      before do
+        ServiceDeployment.create!(commit_sha: 'f7735e5',
+                                  environment_slug: 'dev',
+                                  created_at: Time.new - 30,
+                                  updated_at: Time.new,
+                                  created_by_user: user,
+                                  service: service,
+                                  completed_at: Time.new,
+                                  status: 'completed',
+                                  json_sub_dir: '')
+
+        ServiceDeployment.create!(commit_sha: 'a84b001',
+                                  environment_slug: 'staging',
+                                  created_at: Time.new - 300,
+                                  updated_at: Time.new - 240,
+                                  created_by_user: user,
+                                  service: service,
+                                  completed_at: Time.new,
+                                  status: 'completed',
+                                  json_sub_dir: '')
+
+        ServiceDeployment.create!(commit_sha: 'e986a12',
+                                  environment_slug: 'production',
+                                  created_at: Time.new - 300,
+                                  updated_at: Time.new - 240,
+                                  created_by_user: user,
+                                  service: service,
+                                  completed_at: Time.new,
+                                  status: 'completed',
+                                  json_sub_dir: '')
+      end
+
+      it 'provides Github links to the latest deployments for each environment' do
+        visit "/services/#{service.slug}/deployments/status"
+        expect(page).to have_link('f7735e5', href: 'https://github.com/ministryofjustice/fb-sample-json/commit/f7735e5')
+        expect(page).to have_link('a84b001', href: 'https://github.com/ministryofjustice/fb-sample-json/commit/a84b001')
+        expect(page).to have_link('e986a12', href: 'https://github.com/ministryofjustice/fb-sample-json/commit/e986a12')
+      end
     end
 
     def create_deployment

--- a/spec/models/service_deployment_spec.rb
+++ b/spec/models/service_deployment_spec.rb
@@ -74,20 +74,21 @@ describe ServiceDeployment do
                         created_by_user: user)
       end
 
-      # it 'set the Github link for the commit sha' do
-      #   commit_link = ServiceDeployment.generate_github_link(service: service, commit_sha: 'a123e56')
-      #   expect(commit_link).to eq('https://github.com/some-organisation/some-repository/commit/a123e56')
-      # end
-
-      it 'set the Github link for the commit sha if git repository exists' do
+      before do
         subject.update_attributes(service: service, commit_sha: 'a123e56')
-        expect(subject.generate_github_link).to eq('https://github.com/some-organisation/some-repository/commit/a123e56')
       end
 
-      it 'does not create a link for the commit sha if git reposity does not exist' do
-        service.git_repo_url = ''
-        subject.update_attributes(service: service, commit_sha: 'a123e56')
-        expect(subject.generate_github_link).to eq(nil)
+      context 'when the git_repo_url exists' do
+        it 'sets the Github link for the commit sha' do
+          expect(subject.generate_github_link).to eq('https://github.com/some-organisation/some-repository/commit/a123e56')
+        end
+      end
+
+      context 'when the git_repo_url does not exist' do
+        it 'does not create a link for the commit sha' do
+          service.git_repo_url = ''
+          expect(subject.generate_github_link).to eq(nil)
+        end
       end
     end
   end

--- a/spec/models/service_deployment_spec.rb
+++ b/spec/models/service_deployment_spec.rb
@@ -59,4 +59,25 @@ describe ServiceDeployment do
       end
     end
   end
+
+  describe '#generate_commit_link' do
+    context 'given a service' do
+      let(:user) do
+        User.create(id: 'abc123', name: 'test user', email: 'test@example.justice.gov.uk')
+      end
+
+      let(:service) do
+        Service.create!(id: 'fed456',
+                        name: 'My New Service',
+                        slug: 'my-new-service',
+                        git_repo_url: 'https://github.com/some-organisation/some-repository.git',
+                        created_by_user: user)
+      end
+
+      it 'set the Github link for the commit sha' do
+        commit_link = ServiceDeployment.generate_github_link(service: service, commit_sha: 'a123e56')
+        expect(commit_link).to eq('https://github.com/some-organisation/some-repository/commit/a123e56')
+      end
+    end
+  end
 end

--- a/spec/models/service_deployment_spec.rb
+++ b/spec/models/service_deployment_spec.rb
@@ -74,9 +74,20 @@ describe ServiceDeployment do
                         created_by_user: user)
       end
 
-      it 'set the Github link for the commit sha' do
-        commit_link = ServiceDeployment.generate_github_link(service: service, commit_sha: 'a123e56')
-        expect(commit_link).to eq('https://github.com/some-organisation/some-repository/commit/a123e56')
+      # it 'set the Github link for the commit sha' do
+      #   commit_link = ServiceDeployment.generate_github_link(service: service, commit_sha: 'a123e56')
+      #   expect(commit_link).to eq('https://github.com/some-organisation/some-repository/commit/a123e56')
+      # end
+
+      it 'set the Github link for the commit sha if git repository exists' do
+        subject.update_attributes(service: service, commit_sha: 'a123e56')
+        expect(subject.generate_github_link).to eq('https://github.com/some-organisation/some-repository/commit/a123e56')
+      end
+
+      it 'does not create a link for the commit sha if git reposity does not exist' do
+        service.git_repo_url = ''
+        subject.update_attributes(service: service, commit_sha: 'a123e56')
+        expect(subject.generate_github_link).to eq(nil)
       end
     end
   end

--- a/spec/models/service_deployment_spec.rb
+++ b/spec/models/service_deployment_spec.rb
@@ -85,8 +85,11 @@ describe ServiceDeployment do
       end
 
       context 'when the git_repo_url does not exist' do
-        it 'does not create a link for the commit sha' do
+        before do
           service.git_repo_url = ''
+        end
+
+        it 'does not create a link for the commit sha' do
           expect(subject.generate_github_link).to eq(nil)
         end
       end


### PR DESCRIPTION
This requirement was uncovered from user testing, to create a hyperlinkfrom the commit-sha to the actual Github commit when the user creates a new deployment.