### PR TITLE
Display pagination for services

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -2,9 +2,14 @@ class ServicesController < ApplicationController
   before_action :require_user!
   before_action :load_and_authorize_resource!, only: [:edit, :update, :destroy, :show]
 
+  include Pagy::Backend
+
   def index
+    params[:per_page] ||= 10
+    params[:page] ||= 1
+
     authorize(Service)
-    @services = Service.visible_to(current_user)
+    @pagy, @services = pagy_array((Service.visible_to(current_user).sort_by &:name), items: params[:per_page])
   end
 
   def new

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,0 +1,3 @@
+module ServiceHelper
+  include Pagy::Frontend
+end

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -12,6 +12,7 @@
       %th{ scope: 'col' }
         = t('.actions')
     %tbody
+      = pagy_nav(@pagy).html_safe
       = render partial: 'service', collection: @services
 
 = link_to t('.new_service'), new_service_path, class: 'button button-cta'

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,19 @@
+# See the Pagy documentation: https://ddnexus.github.io/pagy/extras/array
+class Pagy
+  # Add specialized backend methods to paginate array collections
+  module Backend
+    private
+
+    # Return Pagy object and items
+    def pagy_array(array, vars={})
+      pagy = Pagy.new(pagy_array_get_vars(array, vars))
+      return pagy, array[pagy.offset, pagy.items]
+    end
+
+    def pagy_array_get_vars(array, vars)
+      # Return the merged variables to initialize the Pagy object
+      { count: array.count,
+        page:  params[vars[:page_param]||VARS[:page_param]] }.merge!(vars)
+    end
+  end
+end

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -6,7 +6,7 @@ describe 'visiting /services' do
   end
 
   context 'as a logged in user' do
-    let(:user){ User.create(id: 'abc123', name: 'test user', email: 'test@example.justice.gov.uk') }
+    let(:user) { User.find_or_create_by(name: 'test user', email: 'test@example.justice.gov.uk') }
     before do
       login_as!(user)
     end
@@ -29,6 +29,45 @@ describe 'visiting /services' do
 
       it 'shows a New Service page' do
         expect(page).to have_content('New Service')
+      end
+    end
+
+    describe 'viewing service list' do
+      context 'when there are more than 10 services' do
+        before do
+          14.times { |i| create_service(i) }
+          visit '/services'
+        end
+
+        it 'enables link to next page if service list is greater than 10' do
+          expect(page).to have_link('Next')
+        end
+
+        it 'enables link to previous page if not on the first page' do
+          click_link('Next')
+          expect(page).to have_link('Prev')
+        end
+      end
+
+      context 'when there are less than 10 services' do
+        before do
+          9.times { |i| create_service(i) }
+          visit '/services'
+        end
+
+        it 'does not enable a link to the next page' do
+          expect(page).to_not have_link('Next')
+        end
+
+        it 'does not enable link to the previous page' do
+          expect(page).to_not have_link('Prev')
+        end
+      end
+
+      def create_service(number)
+        Service.create(name: 'Service ' + number.to_s,
+                       git_repo_url: 'https://github.com/ministryofjustice/fb-sample-json.git',
+                       created_by_user: user)
       end
     end
 
@@ -135,6 +174,7 @@ describe 'visiting /services' do
               expect(page).to have_content('Status of your service in the available environments')
             end
           end
+
           context 'to something invalid' do
             let(:new_name) { '?' }
 

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -39,13 +39,17 @@ describe 'visiting /services' do
           visit '/services'
         end
 
-        it 'enables link to next page if service list is greater than 10' do
+        it 'enables link to next page' do
           expect(page).to have_link('Next')
         end
 
-        it 'enables link to previous page if not on the first page' do
-          click_link('Next')
-          expect(page).to have_link('Prev')
+        context 'if not on the first page' do
+          before do
+            click_link('Next')
+          end
+          it 'enables link to previous page' do
+            expect(page).to have_link('Prev')
+          end
         end
       end
 


### PR DESCRIPTION
The pagination allows up to 10 services to be displayed on a page.
'Next' and 'Prev' links allow the user to navigate through the pages.