### PR TITLE
Handle existing user with email but not oauth identity

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -2,9 +2,14 @@ class ServicesController < ApplicationController
   before_action :require_user!
   before_action :load_and_authorize_resource!, only: [:edit, :update, :destroy, :show]
 
+  include Pagy::Backend
+
   def index
+    params[:per_page] ||= 10
+    params[:page] ||= 1
+
     authorize(Service)
-    @services = Service.visible_to(current_user)
+    @pagy, @services = pagy_array((Service.visible_to(current_user).sort_by &:name), items: params[:per_page])
   end
 
   def new

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,0 +1,3 @@
+module ServiceHelper
+  include Pagy::Frontend
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,11 @@ class User < ActiveRecord::Base
     "#{name} (#{email})"
   end
 
+  def has_identity?(identity)
+    identities.any? do |id|
+      id.uid == identity.uid &&
+      id.provider == identity.provider
+    end
+  end
+
 end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,9 +1,14 @@
 class UserService
   def self.existing_user_with(identity)
-    identity = Identity.where(
+    Identity.where(
       uid: identity.uid,
       provider: identity.provider
-    ).first.try(:user)
+    ).first.try(:user) || \
+      User.where(email: identity.email).first
+  end
+
+  def find_by_email(email)
+
   end
 
   def self.create!(identity)
@@ -11,12 +16,16 @@ class UserService
       name: identity.name,
       email: identity.email
     )
-    new_user.identities << Identity.new(
+    add_identity!(new_user, identity)
+    new_user
+  end
+
+  def self.add_identity!(user, identity)
+    user.identities << Identity.new(
       name: identity.name,
       email: identity.email,
       provider: identity.provider,
       uid: identity.uid
     )
-    new_user
   end
 end

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -12,6 +12,7 @@
       %th{ scope: 'col' }
         = t('.actions')
     %tbody
+      = pagy_nav(@pagy).html_safe
       = render partial: 'service', collection: @services
 
 = link_to t('.new_service'), new_service_path, class: 'button button-cta'

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,19 @@
+# See the Pagy documentation: https://ddnexus.github.io/pagy/extras/array
+class Pagy
+  # Add specialized backend methods to paginate array collections
+  module Backend
+    private
+
+    # Return Pagy object and items
+    def pagy_array(array, vars={})
+      pagy = Pagy.new(pagy_array_get_vars(array, vars))
+      return pagy, array[pagy.offset, pagy.items]
+    end
+
+    def pagy_array_get_vars(array, vars)
+      # Return the merged variables to initialize the Pagy object
+      { count: array.count,
+        page:  params[vars[:page_param]||VARS[:page_param]] }.merge!(vars)
+    end
+  end
+end

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -42,17 +42,33 @@ describe 'logging in as a particular user' do
     context 'and already exists' do
       before do
         user.save!
-        user.identities << Identity.new(provider: 'auth0', uid: 'google-oauth2|012345678900123456789', email: user.email, name: user.name)
+      end
+      context 'with the oauth identity' do
+        before do
+          user.identities << Identity.new(provider: 'auth0', uid: 'google-oauth2|012345678900123456789', email: user.email, name: user.name)
+        end
+
+        it 'redirects me to the services page' do
+          login_as!(user)
+          expect(page.current_url).to eq(services_url)
+        end
+
+        it 'shows me a welcome back message with my name' do
+          login_as!(user)
+          expect(page).to have_content("Welcome back, #{user.name}!")
+        end
       end
 
-      it 'redirects me to the services page' do
-        login_as!(user)
-        expect(page.current_url).to eq(services_url)
-      end
+      context 'without the oauth identity' do
+        it 'redirects me to the services page' do
+          login_as!(user)
+          expect(page.current_url).to eq(services_url)
+        end
 
-      it 'shows me a welcome back message with my name' do
-        login_as!(user)
-        expect(page).to have_content("Welcome back, #{user.name}!")
+        it 'shows me a welcome back message with my name' do
+          login_as!(user)
+          expect(page).to have_content("Welcome back, #{user.name}!")
+        end
       end
     end
   end

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -6,7 +6,7 @@ describe 'visiting /services' do
   end
 
   context 'as a logged in user' do
-    let(:user){ User.create(id: 'abc123', name: 'test user', email: 'test@example.justice.gov.uk') }
+    let(:user) { User.new(id: 'abc123', name: 'test user', email: 'test@example.justice.gov.uk') }
     before do
       login_as!(user)
     end
@@ -29,6 +29,46 @@ describe 'visiting /services' do
 
       it 'shows a New Service page' do
         expect(page).to have_content('New Service')
+      end
+    end
+
+    describe 'viewing service list' do
+      context 'when there are more than 10 services' do
+        before do
+          14.times { |i| create_service(i) }
+          visit '/services'
+        end
+
+        it 'enables link to next page if service list is greater than 10' do
+          expect(page).to have_link('Next')
+        end
+
+        it 'enables link to previous page if not on the first page' do
+          click_link('Next')
+          expect(page).to have_link('Prev')
+        end
+      end
+
+      context 'when there are less than 10 services' do
+        before do
+          9.times { |i| create_service(i) }
+          visit '/services'
+        end
+
+        it 'does not enable a link to the next page' do
+          expect(page).to_not have_link('Next')
+        end
+
+        it 'does not enable link to the previous page' do
+          expect(page).to_not have_link('Prev')
+        end
+      end
+
+      def create_service(number)
+        test_user = User.first
+        Service.create(name: 'Service ' + number.to_s,
+                       git_repo_url: 'https://github.com/ministryofjustice/fb-sample-json.git',
+                       created_by_user: test_user)
       end
     end
 
@@ -135,6 +175,7 @@ describe 'visiting /services' do
               expect(page).to have_content('Status of your service in the available environments')
             end
           end
+
           context 'to something invalid' do
             let(:new_name) { '?' }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe User do
+  let(:user) { User.new(name: 'test user', email: 'test@example.com') }
+
+  describe '#name_and_email' do
+    it 'is of the form {name} "({email})"' do
+      expect(user.name_and_email).to eq('test user (test@example.com)')
+    end
+  end
+
+  describe 'has_identity?' do
+    let(:identity) { Identity.new(uid: 'myuid', provider: 'myprovider') }
+
+    context 'when no identity exists with the given uid & provider' do
+      it 'returns true' do
+        expect(user.has_identity?(identity)).to eq(false)
+      end
+    end
+    context 'when an identity exists with the given uid & provider' do
+      before do
+        user.identities << identity
+      end
+
+      it 'returns true' do
+        expect(user.has_identity?(identity)).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In tests, we found that the `login_as!` method was not behaving
as expected, but instead creating a new user with the same email
yet no OAuth identity. This caused failures in request specs that
relied on services created in a `before` block being visible to
a user also created in a `before` block.

This PR fixes the issue, which will also handle the real-world
edge case of an existing user unlinking their OAuth login, and then
trying to login with it again.
