### PR TITLE
Handle existing user with matching email but no matching oauth id

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,11 @@ class User < ActiveRecord::Base
     "#{name} (#{email})"
   end
 
+  def has_identity?(identity)
+    identities.any? do |id|
+      id.uid == identity.uid &&
+      id.provider == identity.provider
+    end
+  end
+
 end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,9 +1,14 @@
 class UserService
   def self.existing_user_with(identity)
-    identity = Identity.where(
+    Identity.where(
       uid: identity.uid,
       provider: identity.provider
-    ).first.try(:user)
+    ).first.try(:user) || \
+      User.where(email: identity.email).first
+  end
+
+  def find_by_email(email)
+
   end
 
   def self.create!(identity)
@@ -11,12 +16,16 @@ class UserService
       name: identity.name,
       email: identity.email
     )
-    new_user.identities << Identity.new(
+    add_identity!(new_user, identity)
+    new_user
+  end
+
+  def self.add_identity!(user, identity)
+    user.identities << Identity.new(
       name: identity.name,
       email: identity.email,
       provider: identity.provider,
       uid: identity.uid
     )
-    new_user
   end
 end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -7,10 +7,6 @@ class UserService
       User.where(email: identity.email).first
   end
 
-  def find_by_email(email)
-
-  end
-
   def self.create!(identity)
     new_user = User.create!(
       name: identity.name,

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -42,17 +42,33 @@ describe 'logging in as a particular user' do
     context 'and already exists' do
       before do
         user.save!
-        user.identities << Identity.new(provider: 'auth0', uid: 'google-oauth2|012345678900123456789', email: user.email, name: user.name)
+      end
+      context 'with the oauth identity' do
+        before do
+          user.identities << Identity.new(provider: 'auth0', uid: 'google-oauth2|012345678900123456789', email: user.email, name: user.name)
+        end
+
+        it 'redirects me to the services page' do
+          login_as!(user)
+          expect(page.current_url).to eq(services_url)
+        end
+
+        it 'shows me a welcome back message with my name' do
+          login_as!(user)
+          expect(page).to have_content("Welcome back, #{user.name}!")
+        end
       end
 
-      it 'redirects me to the services page' do
-        login_as!(user)
-        expect(page.current_url).to eq(services_url)
-      end
+      context 'without the oauth identity' do
+        it 'redirects me to the services page' do
+          login_as!(user)
+          expect(page.current_url).to eq(services_url)
+        end
 
-      it 'shows me a welcome back message with my name' do
-        login_as!(user)
-        expect(page).to have_content("Welcome back, #{user.name}!")
+        it 'shows me a welcome back message with my name' do
+          login_as!(user)
+          expect(page).to have_content("Welcome back, #{user.name}!")
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe User do
+  let(:user) { User.new(name: 'test user', email: 'test@example.com') }
+
+  describe '#name_and_email' do
+    it 'is of the form {name} "({email})"' do
+      expect(user.name_and_email).to eq('test user (test@example.com)')
+    end
+  end
+
+  describe 'has_identity?' do
+    let(:identity) { Identity.new(uid: 'myuid', provider: 'myprovider') }
+
+    context 'when no identity exists with the given uid & provider' do
+      it 'returns true' do
+        expect(user.has_identity?(identity)).to eq(false)
+      end
+    end
+    context 'when an identity exists with the given uid & provider' do
+      before do
+        user.identities << identity
+      end
+
+      it 'returns true' do
+        expect(user.has_identity?(identity)).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In tests, we found that the `login_as!` method was not behaving
as expected, but instead creating a new user with the same email
yet no OAuth identity. This caused failures in request specs that
relied on services created in a `before` block being visible to
a user also created in a `before` block.

This PR fixes the issue, which will also handle the real-world
edge case of an existing user unlinking their OAuth login, and then
trying to login with it again.