### PR TITLE
Do not show status or `Check now` button on service status

### DIFF
--- a/app/views/services/_environment.html.haml
+++ b/app/views/services/_environment.html.haml
@@ -11,13 +11,16 @@
       %span{ class: "status status-#{environment.status.to_s.first}xx" }
         = environment.status
     - else
-      \-
+      %span= t('.no_deployment')
   %td
     = environment.timestamp ? localize(environment.timestamp) : "-"
   %td.actions
-    = button_to t('.check_now'),
-                service_status_checks_path(environment.service),
-                params: {service_id: environment.service.slug, environment_slug: environment.environment_slug},
-                class: 'button',
-                remote: true,
-                data: {disable_with: t('.checking')}
+    - if environment.status
+      = button_to t('.check_now'),
+                  service_status_checks_path(environment.service),
+                  params: {service_id: environment.service.slug, environment_slug: environment.environment_slug},
+                  class: 'button',
+                  remote: true,
+                  data: {disable_with: t('.checking')}
+    - else
+      \-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,7 @@ en:
     environment:
       checking: 'checking...'
       check_now: 'Check now'
+      no_deployment: 'Not yet deployed'
     index:
       actions: Actions
       caption: Your Services

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -193,5 +193,52 @@ describe 'visiting /services' do
         end
       end
     end
+
+    describe 'viewing service status' do
+      context 'when I have a service' do
+        let(:service) do
+          Service.create!(name: 'ABC Service', git_repo_url: 'https://github.com/some-org/some-repo.git',
+                          created_by_user: user)
+        end
+
+        context 'with no deployments' do
+          before do
+            visit "/services/#{service.slug}"
+          end
+
+          it 'there is no status' do
+            expect(page).not_to have_selector('span.status')
+            expect(page).to have_selector('span', text: 'Not yet deployed')
+          end
+
+          it 'there is no `Check now` button' do
+            expect(page).not_to have_button('Check now')
+          end
+        end
+
+        context 'with deployments' do
+          before do
+            ServiceStatusCheck.create!(environment_slug: 'dev',
+                                       status: 1,
+                                       time_taken: 30.0,
+                                       timestamp: Time.new,
+                                       created_at: Time.new,
+                                       updated_at: Time.new,
+                                       url: 'url.test',
+                                       service: service)
+
+            visit "/services/#{service.slug}"
+          end
+
+          it 'there is a status' do
+            expect(page).to have_selector('span.status')
+          end
+
+          it 'there is a `Check now` button' do
+            expect(page).to have_button('Check now')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -206,13 +206,13 @@ describe 'visiting /services' do
             visit "/services/#{service.slug}"
           end
 
-          it 'there is no status' do
+          it 'does not show a status' do
             expect(page).not_to have_selector('span.status')
-            expect(page).to have_selector('span', text: 'Not yet deployed')
+            expect(page).to have_selector('span', text: I18n.t('services.environment.no_deployment'))
           end
 
-          it 'there is no `Check now` button' do
-            expect(page).not_to have_button('Check now')
+          it 'does not show a `Check now` button' do
+            expect(page).not_to have_button(I18n.t('services.environment.check_now'))
           end
         end
 
@@ -230,12 +230,12 @@ describe 'visiting /services' do
             visit "/services/#{service.slug}"
           end
 
-          it 'there is a status' do
+          it 'does show a status' do
             expect(page).to have_selector('span.status')
           end
 
-          it 'there is a `Check now` button' do
-            expect(page).to have_button('Check now')
+          it 'does show a `Check now` button' do
+            expect(page).to have_button(I18n.t('services.environment.check_now'))
           end
         end
       end


### PR DESCRIPTION
If there are no deployments for an environment. The message`Not yet deployed` is displayed in the status column.