### PR TITLE
Alert user to deploy when the config params has changed

### DIFF
--- a/app/controllers/services/config_params_controller.rb
+++ b/app/controllers/services/config_params_controller.rb
@@ -30,6 +30,12 @@ class Services::ConfigParamsController < ApplicationController
     authorize(@config_param)
 
     if @config_param.save
+      flash[:notice] = t(
+          :success,
+          scope: [:services, :config_params, :create],
+          name: @config_param.name,
+          environment: ServiceEnvironment.name_of(@config_param.environment_slug)
+      )
       redirect_to action: :index, service_id: @service, env: @config_param.environment_slug
     else
       render :new

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,7 +121,7 @@ en:
         edit: Edit
         empty_value: (empty)
       create:
-        success: Config Param '%{name}' (%{environment}) created successfully
+        success: Config Param '%{name}' (%{environment}) created successfully. For the changes to take effect this needs to be deployed
       edit:
         heading: Editing '%{name}' (%{environment})
       form:
@@ -131,7 +131,7 @@ en:
         lede_html:
           These will be passed to your service as environment variables
       update:
-        success: Config Param '%{name}' (%{environment}) updated successfully
+        success: Config Param '%{name}' (%{environment}) updated successfully. For the changes to take effect this needs to be deployed
     deployments:
       environments_nav:
         all_envs_status: '(all)'

--- a/spec/features/config_params_spec.rb
+++ b/spec/features/config_params_spec.rb
@@ -1,0 +1,62 @@
+require 'capybara_helper'
+
+describe "visiting a service's config params page" do
+  context 'as a logged in user' do
+    let(:user) { User.find_or_create_by(name: 'test user', email: 'test@example.justice.gov.uk') }
+    let(:service) do
+      Service.create(name: 'Test Service',
+                     git_repo_url: 'https://github.com/some_org/some_repo.git',
+                     created_by_user: user)
+    end
+
+    before do
+      login_as!(user)
+    end
+
+    let(:name) { 'TEST_1' }
+    let(:value) { 'abc456' }
+    let(:environment) { 'Development' }
+
+    context 'when adding new environment variables' do
+      before do
+        visit "/services/#{service.slug}/config_params"
+        fill_in('Name', with: name)
+        fill_in('Value', with: value)
+        click_button('Save')
+      end
+
+      it 'displays a message advising the user to deploy for changes to take effect' do
+        expect(page).to have_selector('div.flash.flash-notice',
+                                      text: I18n.t('services.config_params.create.success',
+                                                   name: name, environment: environment))
+      end
+    end
+
+    context 'when changing existing environment variables' do
+      let(:env_slug) { 'dev' }
+      let(:config) do
+        ServiceConfigParam.create!(environment_slug: env_slug,
+                                   name: name,
+                                   value: value,
+                                   service: service,
+                                   last_updated_by_user: user)
+      end
+
+      let(:changed_name) { 'TEST_2' }
+      let(:changed_value) { 'xyz987' }
+
+      before do
+        visit "/services/#{service.slug}/config_params/#{config.id}/edit"
+        fill_in('Name', with: changed_name)
+        fill_in('Value', with: changed_value)
+        click_button('Save')
+      end
+
+      it 'displays a message advising the user to deploy for changes to take effect' do
+        expect(page).to have_selector('div.flash.flash-notice',
+                                      text: I18n.t('services.config_params.update.success',
+                                                   name: changed_name, environment: environment))
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a service's config param has been changed but not yet deployed. Indicate to the user that they need to deploy for their changes to take effect.