### PR TITLE
Add service token generation/re-generation & kubernetes secret

### DIFF
--- a/app/jobs/deploy_service_job.rb
+++ b/app/jobs/deploy_service_job.rb
@@ -20,6 +20,13 @@ class DeployServiceJob < ApplicationJob
       commit_sha: commit
     )
 
+    log_for_user(:creating_service_token_secret)
+    DeploymentService.create_service_token_secret(
+      config_dir: config_dir,
+      environment_slug: @deployment.environment_slug,
+      service: @deployment.service,
+    )
+
     log_for_user(:deploying_service)
     DeploymentService.setup_service(
       config_dir: config_dir,
@@ -62,6 +69,7 @@ class DeployServiceJob < ApplicationJob
   end
 
   def on_non_retryable_exception(error)
+    log_for_user(:failed)
     @deployment.fail!(retryable: false) if @deployment
     super
   end

--- a/app/jobs/deploy_service_job.rb
+++ b/app/jobs/deploy_service_job.rb
@@ -26,17 +26,16 @@ class DeployServiceJob < ApplicationJob
       environment_slug: @deployment.environment_slug,
       service: @deployment.service,
     )
-
-    log_for_user(:deploying_service)
-    DeploymentService.setup_service(
+    log_for_user(:configuring_params)
+    DeploymentService.configure_env_vars(
       config_dir: config_dir,
       environment_slug: @deployment.environment_slug,
       service: @deployment.service,
       deployment: @deployment
     )
 
-    log_for_user(:configuring_params)
-    DeploymentService.configure_env_vars(
+    log_for_user(:deploying_service)
+    DeploymentService.setup_service(
       config_dir: config_dir,
       environment_slug: @deployment.environment_slug,
       service: @deployment.service,

--- a/app/services/cloud_platform_adapter.rb
+++ b/app/services/cloud_platform_adapter.rb
@@ -45,7 +45,8 @@ class CloudPlatformAdapter < GenericKubernetesPlatformAdapter
       image: image,
       json_repo: service.git_repo_url,
       commit_ref: deployment.commit_sha,
-      config_map_name: kubernetes_adapter.config_map_name(service: service)
+      config_map_name: kubernetes_adapter.config_map_name(service: service),
+      token_secret_name: token_secret_name(service)
     )
   end
 

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -81,6 +81,15 @@ class DeploymentService
     )
   end
 
+  def self.create_service_token_secret(environment_slug:, service:, config_dir:)
+    adapter = adapter_for(environment_slug)
+    adapter.create_service_token_secret(
+      config_dir: config_dir,
+      service: service,
+      environment_slug: environment_slug
+    )
+  end
+
   def self.system_config_for(service:, deployment:, environment_slug:)
     {
       'SERVICEDATA' => File.join('/usr/app/', deployment.json_sub_dir.to_s),

--- a/app/services/generic_kubernetes_platform_adapter.rb
+++ b/app/services/generic_kubernetes_platform_adapter.rb
@@ -25,6 +25,15 @@ class GenericKubernetesPlatformAdapter
     end
   end
 
+  def create_service_token_secret(environment_slug:, service:, config_dir:)
+    kubernetes_adapter.create_secret(
+      name: token_secret_name(service),
+      key_ref: "token",
+      value: service.token,
+      config_dir: config_dir
+    )
+  end
+
   def service_is_running?(service:)
     kubernetes_adapter.exists_in_namespace?(
       name: service.slug,
@@ -60,5 +69,9 @@ class GenericKubernetesPlatformAdapter
     if deployment_exists?(service: service)
       delete_deployment(service: service)
     end
+  end
+
+  def token_secret_name(service)
+    "fb-service-#{service.slug}-token-#{@environment.slug}"
   end
 end

--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -20,6 +20,22 @@ class KubernetesAdapter
     )
   end
 
+  def create_secret(name:, key_ref:, value:, config_dir:)
+    config_file_path = File.join(config_dir, 'service-token-secret.yml')
+
+    write_config_file(
+      file: config_file_path,
+      content: secret(
+        name: name,
+        key_ref: key_ref,
+        value: value,
+      )
+    )
+
+    apply_file(file: config_file_path)
+  end
+
+
   def namespace_exists?
     begin
       ShellAdapter.exec(
@@ -150,7 +166,8 @@ class KubernetesAdapter
       image:,
       json_repo:,
       commit_ref:,
-      config_map_name:
+      config_map_name:,
+      token_secret_name:
     )
     file = File.join(config_dir, 'deployment.yml')
     write_config_file(
@@ -161,7 +178,8 @@ class KubernetesAdapter
           image: image,
           json_repo: json_repo,
           commit_ref: commit_ref,
-          config_map_name: config_map_name
+          config_map_name: config_map_name,
+          token_secret_name: token_secret_name
       )
     )
     apply_file(file: file)
@@ -190,6 +208,7 @@ class KubernetesAdapter
   end
 
   def write_config_file(file:, content:)
+    FileUtils.mkdir_p(File.dirname(file))
     File.open(file, 'w+') do |f|
       f << content
     end
@@ -338,7 +357,19 @@ class KubernetesAdapter
     ENDHEREDOC
   end
 
-  def deployment(name:, json_repo:, commit_ref:, container_port:, image:, config_map_name:)
+  def secret(name:, key_ref:, value:)
+    <<~ENDHEREDOC
+    apiVersion: v1
+    data:
+      #{key_ref}: #{Base64.encode64(value)}
+    kind: Secret
+    metadata:
+      name: #{name}
+      namespace: #{@environment.namespace}
+    ENDHEREDOC
+  end
+
+  def deployment(name:, json_repo:, commit_ref:, container_port:, image:, config_map_name:, token_secret_name:)
     cmd = "git clone #{json_repo} /usr/app/ && cd /usr/app && git checkout #{commit_ref}"
     <<~ENDHEREDOC
     apiVersion: apps/v1beta2
@@ -370,6 +401,14 @@ class KubernetesAdapter
             envFrom:
             - configMapRef:
                 name: #{config_map_name}
+            # individual secret for the service token, so that it can be
+            # read by the user data store in isolation
+            env:
+              - name: SERVICE_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: #{token_secret_name}
+                    key: token
             image: #{image}
             ports:
             - containerPort: #{container_port}

--- a/app/services/minikube_adapter.rb
+++ b/app/services/minikube_adapter.rb
@@ -58,7 +58,8 @@ class MinikubeAdapter < GenericKubernetesPlatformAdapter
       image: image,
       json_repo: service.git_repo_url,
       commit_ref: deployment.commit_sha,
-      config_map_name: kubernetes_adapter.config_map_name(service: service)
+      config_map_name: kubernetes_adapter.config_map_name(service: service),
+      token_secret_name: token_secret_name(service)
     )
   end
 

--- a/app/views/services/_form.html.haml
+++ b/app/views/services/_form.html.haml
@@ -5,4 +5,15 @@
     = f.text_field :slug, maxlength: 64
   .form-group
     = f.text_field :git_repo_url, maxlength: 2048, required: true
+  - if service.persisted?
+    .form-group
+      %details
+        %summary
+          %span.summary
+            = t '.token'
+        .panel.panel-border-narrow
+          %pre
+            = f.text_field :token, maxlength: 32, required: false
+
+  .form-group
     = f.submit button_label, class: 'button button-cta'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,9 @@ en:
           <em>(optional)</em> This will form the first part of your services' initial URL.<br />
           Must contain 3-64 characters, and only letters, numbers and hyphens (-)<br />
           Must be unique. If you leave this blank, we'll generate one for you
+        token_html:
+          Clear this field to regenerate your service's token.<br />
+          If you're not sure what this means, leave this field as it is
       service_config_param:
         name_html:
           Must be 3-64 characters long, and contain only
@@ -67,6 +70,7 @@ en:
         git_repo_url: URL of the service config JSON Git repository
         name: Service name
         slug: Service "slug"
+        token: Secret token
       service_deployment:
         commit_sha: Commit SHA, branch, or tag
         json_sub_dir: Relative path to your service's JSON
@@ -77,8 +81,10 @@ en:
     all_done: 'ALL DONE'
     complete: 'Finished - writing status back to Deployment'
     configuring_params: 'Updating config params'
+    creating_service_token_secret: 'Creating secret for service token'
     deploying_service: 'Deploying service'
     exposing: 'Allowing inbound traffic'
+    failed: 'JOB FAILED!'
     reading_commit: 'Reading commit SHA'
     restarting: 'Restarting service'
     starting: 'Starting job %{job_id} for ServiceDeployment %{service_deployment_id}'
@@ -154,7 +160,7 @@ en:
         lede_html:
           Latest deployments for each environment
     create:
-      success: Your new service has been created successfully
+      success: Your new service has been created. You'll need to deploy your service to an environment to see it on the web.
     destroy:
       success: Service "%{service}" deleted successfully
     edit:
@@ -165,6 +171,8 @@ en:
       checking: 'checking...'
       check_now: 'Check now'
       no_deployment: 'Not yet deployed'
+    form:
+      token: Secret token (click to show/regenerate)
     index:
       actions: Actions
       caption: Your Services
@@ -209,7 +217,7 @@ en:
       timestamp: Checked at
       url: URL
     update:
-      success: Service "%{service}" updated successfully
+      success: Service "%{service}" updated successfully. You'll need to deploy your service for these changes to take effect on the web.
   teams:
     create:
       success: Your new team has been created successfully

--- a/db/migrate/20180924153822_add_service_token.rb
+++ b/db/migrate/20180924153822_add_service_token.rb
@@ -1,0 +1,6 @@
+class AddServiceToken < ActiveRecord::Migration[5.2]
+  def change
+    add_column :services, :token, :string, null: true
+    add_index :services, [:token], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_21_072345) do
+ActiveRecord::Schema.define(version: 2018_09_24_153822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -93,6 +93,8 @@ ActiveRecord::Schema.define(version: 2018_07_21_072345) do
     t.uuid "created_by_user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "token"
+    t.index ["token"], name: "index_services_on_token", unique: true
   end
 
   create_table "team_members", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -80,6 +80,10 @@ describe 'visiting /services' do
         visit new_service_path
       end
 
+      it 'does not have a token field' do
+        expect(page).to_not have_content(I18n.t(:token, scope: [:services, :form]))
+      end
+
       context 'when I fill in the Service name' do
         before do
           fill_in('Service name', with: name)
@@ -114,7 +118,7 @@ describe 'visiting /services' do
                 end
 
                 it 'shows me a notice saying it was created successfully' do
-                  expect(page).to have_content('Your new service has been created successfully')
+                  expect(page).to have_content(I18n.t(:success, scope: [:services, :create], service: name))
                 end
               end
             end
@@ -171,7 +175,7 @@ describe 'visiting /services' do
             let(:new_name) { 'My First Service v2' }
 
             it 'shows me a message saying it was updated successfully' do
-              expect(page).to have_content('Service "My First Service v2" updated successfully')
+              expect(page).to have_content(I18n.t(:success, scope: [:services, :update], service: new_name))
             end
 
             it 'shows me the status of my new service' do

--- a/spec/jobs/deploy_service_job_spec.rb
+++ b/spec/jobs/deploy_service_job_spec.rb
@@ -24,6 +24,7 @@ describe DeployServiceJob do
     allow(DeploymentService).to receive(:expose).and_return('expose-result')
     allow(DeploymentService).to receive(:configure_env_vars).and_return('configure_env_vars-result')
     allow(DeploymentService).to receive(:restart_service).and_return('restart_service-result')
+    allow(DeploymentService).to receive(:create_service_token_secret).and_return('create_service_token_secret-result')
   end
 
   describe '#perform' do
@@ -117,7 +118,7 @@ describe DeployServiceJob do
     end
 
     it 'restarts the service' do
-      allow(DeploymentService).to receive(:restart_service).with(
+      expect(DeploymentService).to receive(:restart_service).with(
         service: service,
         environment_slug: 'myenv'
       )

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -133,6 +133,17 @@ describe Service do
         end
       end
     end
+
+    context 'with an empty token' do
+      before do
+        subject.token = nil
+      end
+
+      it 'generates a token' do
+        expect{ subject.valid? }.to change(subject, :token)
+        expect(subject.token).to_not be_blank
+      end
+    end
   end
 
   describe '#to_param' do


### PR DESCRIPTION
The [user datastore](https://github.com/ministryofjustice/fb-user-datastore) requires Publisher to 
* generate a unique token for each service
* allow the user to update or re-generate it
* deploy the token as a Kubernetes secret to be injected into the service's containers.

This PR adds all the above.

<img width="645" alt="screen shot 2018-09-25 at 11 36 16" src="https://user-images.githubusercontent.com/134501/46009371-3bd28280-c0b7-11e8-8a56-d29a2ac7dbb9.png">



