### PR TITLE
add rules from .gitignore into .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,9 +21,6 @@ tmp/*
 # Ignore assets - we precompile them as part of the docker build
 /public/assets
 
-# Ignore master key for decrypting credentials and more.
-/config/master.key
-
 # dotenv gem loads .env files automatically
 .env
 *.env

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,32 @@
-.git
-.dockerignore
 .byebug_history
+.dockerignore
+.env
+.*.env
+.git
 log/*
 tmp/*
+
+# Mac Finder image thumbnail dbs
+.DS_Store
+
+# Ignore bundler config.
+/.bundle
+
+# Ignore uploaded files in development
+/storage/*
+
+/node_modules
+/yarn-error.log
+
+# Ignore assets - we precompile them as part of the docker build
+/public/assets
+
+# Ignore master key for decrypting credentials and more.
+/config/master.key
+
+# dotenv gem loads .env files automatically
+.env
+*.env
+
+# test coverage reports
+/coverage


### PR DESCRIPTION
I found that some local .env files were being included into the docker image and hence deployed to production.

This PR replicates all the rules from the .gitignore file to the .dockerignore file