### PR TITLE
Add environment variables for the user datastore into the services

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -404,6 +404,10 @@ class KubernetesAdapter
             # individual secret for the service token, so that it can be
             # read by the user data store in isolation
             env:
+              - name: USER_DATASTORE_URL
+                value: #{@environment.user_datastore_url} 
+              - name: SERVICE_SLUG
+                value: #{name}
               - name: SERVICE_TOKEN
                 valueFrom:
                   secretKeyRef:

--- a/app/value_objects/service_environment.rb
+++ b/app/value_objects/service_environment.rb
@@ -1,6 +1,6 @@
 class ServiceEnvironment
   attr_accessor :deployment_adapter, :kubectl_context, :name, :slug,
-                :namespace, :protocol, :url_root
+                :namespace, :protocol, :url_root, :user_datastore_url
 
   def self.all
     Rails.configuration.x.service_environments.map do |key, values|
@@ -43,7 +43,7 @@ class ServiceEnvironment
 
   def to_h
     h = {}
-    [:kubectl_context, :name, :namespace, :protocol, :url_root].each do |key|
+    [:kubectl_context, :name, :namespace, :protocol, :url_root, :user_datastore_url].each do |key|
       h[key] = send(key)
     end
     h

--- a/config/initializers/service_environments.rb
+++ b/config/initializers/service_environments.rb
@@ -5,7 +5,8 @@ ALL_ENVS = {
     name: 'Development',
     namespace: 'formbuilder-services-dev',
     protocol: 'https://',
-    url_root: 'apps.cloud-platform-live-0.k8s.integration.dsd.io'
+    url_root: 'apps.cloud-platform-live-0.k8s.integration.dsd.io',
+    user_datastore_url: 'http://fb-user-datastore-api-svc-dev.formbuilder-platform-dev/'
   },
   staging: {
     deployment_adapter: 'cloud_platform',
@@ -13,7 +14,8 @@ ALL_ENVS = {
     name: 'Staging',
     namespace: 'formbuilder-services-staging',
     protocol: 'https://',
-    url_root: 'apps.cloud-platform-live-0.k8s.integration.dsd.io'
+    url_root: 'apps.cloud-platform-live-0.k8s.integration.dsd.io',
+    user_datastore_url: 'http://fb-user-datastore-api-svc-staging.formbuilder-platform-staging/'
   },
   production: {
     deployment_adapter: 'cloud_platform',
@@ -21,7 +23,8 @@ ALL_ENVS = {
     name: 'Production',
     namespace: 'formbuilder-services-production',
     protocol: 'https://',
-    url_root: 'apps.cloud-platform-live-0.k8s.integration.dsd.io'
+    url_root: 'apps.cloud-platform-live-0.k8s.integration.dsd.io',
+    user_datastore_url: 'http://fb-user-datastore-api-svc-production.formbuilder-platform-production/'
   }
 }
 # only use minikube on local machines - i.e. dev

--- a/db/migrate/20181003144902_populate_empty_service_tokens.rb
+++ b/db/migrate/20181003144902_populate_empty_service_tokens.rb
@@ -1,0 +1,5 @@
+class PopulateEmptyServiceTokens < ActiveRecord::Migration[5.2]
+  def change
+    Service.where(token: nil).each{|s| s.save!}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_24_153822) do
+ActiveRecord::Schema.define(version: 2018_10_03_144902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
For the running services to store/retrieve their data to/from the new [User Datastore](https://github.com/ministryofjustice/fb-user-datastore), they need two additional environment variables to be injected at deploy time:
*USER_DATASTORE_URL* (where the datastore is and what protocol to access it with)
*SERVICE_TOKEN* (secret key that verifies the identity of the running service to the datastore)

This PR adds those two env vars, plus a migration to make sure all existing services have a token generated.