### PR TITLE
When entering permissions for a service, allow user to create a new team inline

### DIFF
--- a/app/controllers/services/permissions_controller.rb
+++ b/app/controllers/services/permissions_controller.rb
@@ -31,12 +31,16 @@ class Services::PermissionsController < ApplicationController
       if params[:permission][:new_team].present?
         team = Team.create!(name: params[:permission][:new_team], created_by_user: current_user)
         @permission.team_id = team.id unless team.id.nil?
+      elsif [params[:permission][:new_team].present?, params[:permission][:team_id].present?].none?
+        raise ActiveRecord::RecordNotFound
       end
 
-      authorize(@permission)
-      @permission.save!
-      flash[:success] = I18n.t('services.permissions.create.success' )
-      redirect_to action: :index, service_id: @service
+      if params[:permission][:new_team].present? || params[:permission][:team_id].present?
+        authorize(@permission)
+        @permission.save!
+        flash[:success] = I18n.t('services.permissions.create.success' )
+        redirect_to action: :index, service_id: @service
+      end
 
     rescue StandardError => e
       permissions_error_message(e)

--- a/app/controllers/services/permissions_controller.rb
+++ b/app/controllers/services/permissions_controller.rb
@@ -28,7 +28,7 @@ class Services::PermissionsController < ApplicationController
     )
 
     begin
-      team = find_or_create_team
+      team = find_or_create_team!
       @permission.team_id = team.id
 
       authorize(@permission)
@@ -93,11 +93,11 @@ class Services::PermissionsController < ApplicationController
                            default: I18n.t(:default, scope: scope))
   end
 
-  def find_or_create_team
-    if params[:permission][:new_team].present?
-      Team.create!(name: params[:permission][:new_team], created_by_user: current_user)
+  def find_or_create_team!(opts = params[:permission])
+    if opts[:new_team].present?
+      Team.create!(name: opts[:new_team], created_by_user: current_user)
     else
-      Team.find(params[:permission][:team_id])
+      Team.find(opts[:team_id])
     end
   end
 end

--- a/app/views/services/permissions/_form.html.haml
+++ b/app/views/services/permissions/_form.html.haml
@@ -1,10 +1,12 @@
 = form_with model: @permission, url: update_or_create(@permission), local: true do |f|
   %tr.in-form
     %td
+      = f.label 'permission[team_id]', 'Select an existing team', class: 'form-label'
       = select_tag 'permission[team_id]',
                     options_from_collection_for_select( @possible_teams,
                                                         :id,
                                                         :name),
                     class: 'form-control'
+      = f.text_field :new_team, maxlength: 128
     %td.actions
       = f.submit t('.submit'), class: 'button button-cta'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,8 @@ en:
       service_deployment:
         commit_sha: Commit SHA, branch, or tag
         json_sub_dir: Relative path to your service's JSON
+      permission:
+        new_team: 'or create a new team called:'
   auth:
     existing_user:
       welcome_html: "Welcome back, <strong>%{user_name}</strong>!"
@@ -195,6 +197,14 @@ en:
       form:
         submit: Next
     permissions:
+      create:
+        success: Permissions have been added successfully!
+        errors:
+          active_record_record_invalid: Error - Record is invalid
+          record_not_found: Error - Record could not be found
+          pundit_not_authorized_error: Error - You are not authorised to perform this action
+          name_error: Error - you tried to save a new team without providing a team name
+          default: Something went wrong %{message}
       form:
         submit: Grant permission
       index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,9 +201,9 @@ en:
         success: Permissions have been added successfully!
         errors:
           active_record_record_invalid: Error - Record is invalid
-          record_not_found: Error - Record could not be found
+          active_record_record_not_found: Select an existing team or enter a new team
           pundit_not_authorized_error: Error - You are not authorised to perform this action
-          name_error: Error - you tried to save a new team without providing a team name
+          name_error: Error - name is invalid or undefined
           default: Something went wrong %{message}
       form:
         submit: Grant permission

--- a/spec/features/service_permission_spec.rb
+++ b/spec/features/service_permission_spec.rb
@@ -1,0 +1,116 @@
+require 'capybara_helper'
+
+describe 'visiting / service permissions' do
+  let(:user) { User.find_or_create_by(name: 'test user', email: 'test@example.justice.gov.uk') }
+  let(:service) do
+    Service.create!(id: 'fed456', name: 'My New Service', slug: 'my-new-service',
+                    git_repo_url: 'https://github.com/some-organisation/some-repo.git',
+                    created_by_user: user)
+  end
+  context 'as a logged in user' do
+    before do
+      login_as!(user)
+    end
+
+    describe 'creating a new team' do
+      describe 'when no teams exists' do
+        context 'user tries to create a team without a team name' do
+          before do
+            visit "/services/#{service.slug}/permissions"
+            click_button(I18n.t('services.permissions.form.submit'))
+          end
+          it 'displays an error message' do
+            expect(page).to have_content(I18n.t(:name_error,
+                                                scope: [:services, :permissions, :create, :errors]))
+          end
+        end
+        context 'user adds a new team' do
+          before do
+            visit "/services/#{service.slug}/permissions"
+            fill_in('permission[new_team]', with: 'Team Blue')
+            click_button(I18n.t('services.permissions.form.submit'))
+          end
+          it 'grants permission to newly created team' do
+            expect(page).to have_link('Team Blue', href: '/teams/team-blue')
+          end
+          it 'displays a link to remove permissions to newly created team' do
+            expect(page).to have_button(I18n.t('services.permissions.permission.delete'))
+          end
+          it 'displays a success message' do
+            expect(page).to have_content(I18n.t(:success, scope: [:services, :permissions, :create]))
+          end
+        end
+      end
+
+      context 'when there are existing teams' do
+        before do
+          Team.create!(id: 1234, name: 'A Team', slug: 'a-team', created_by_user: user)
+          Team.create!(id: 5678, name: '123 Team', slug: '123-team', created_by_user: user)
+          visit "/services/#{service.slug}/permissions"
+        end
+
+        context 'when both team name is selected and new team entered' do
+          before do
+            fill_in('permission[new_team]', with: 'Team Blue')
+            click_button(I18n.t('services.permissions.form.submit'))
+          end
+          it 'grants permission to the newly created team' do
+            expect(page).to have_link('Team Blue', href: '/teams/team-blue')
+          end
+          it 'displays a success message' do
+            expect(page).to have_content(I18n.t(:success, scope: [:services, :permissions, :create]))
+          end
+        end
+
+        context 'when user enters a duplicate team name' do
+          before do
+            fill_in('permission[new_team]', with: '123 Team')
+            click_button(I18n.t('services.permissions.form.submit'))
+          end
+          it 'displays an error message' do
+            expect(page).to have_content(I18n.t(:active_record_record_invalid,
+                                                scope: [:services, :permissions, :create, :errors]))
+          end
+        end
+
+        context 'when only team name selected' do
+          before do
+            select 'A Team', from: 'permission[team_id]'
+            click_button(I18n.t('services.permissions.form.submit'))
+          end
+          it 'grants permission to the existing team' do
+            expect(page).to have_link('A Team', href: '/teams/a-team')
+          end
+          it 'displays a success message' do
+            expect(page).to have_content(I18n.t(:success, scope: [:services, :permissions, :create]))
+          end
+        end
+
+        context 'when a permission could not be added for a team' do
+          let(:other_user) do
+            User.find_or_create_by(name: 'Another test user', email: 'another_test@example.justice.gov.uk')
+          end
+
+          before do
+            visit "/services/#{service.slug}/permissions"
+            select 'A Team', from: 'permission[team_id]'
+          end
+
+          context 'when there is an authorisation error' do
+            let(:a_team) { Team.find_by_name('A Team') }
+
+            before do
+              a_team.created_by_user = other_user
+              a_team.save
+              click_button(I18n.t('services.permissions.form.submit'))
+            end
+            it 'displays the Pundit authorisation error message' do
+              expect(page).to have_content(I18n.t(:pundit_not_authorized_error,
+                                                  scope: [:services, :permissions, :create, :errors]))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/service_permission_spec.rb
+++ b/spec/features/service_permission_spec.rb
@@ -108,17 +108,6 @@ describe 'visiting / service permissions' do
                                                   scope: [:services, :permissions, :create, :errors]))
             end
           end
-          context 'when there is a no record error' do
-            before do
-              a_team.delete
-              a_team.save
-            end
-            it 'displays the error message' do
-              click_button(I18n.t('services.permissions.form.submit'))
-              expect(page).to have_content(I18n.t(:name_error,
-                                                  scope: [:services, :permissions, :create, :errors]))
-            end
-          end
         end
       end
     end

--- a/spec/features/service_permission_spec.rb
+++ b/spec/features/service_permission_spec.rb
@@ -20,7 +20,7 @@ describe 'visiting / service permissions' do
             click_button(I18n.t('services.permissions.form.submit'))
           end
           it 'displays an error message' do
-            expect(page).to have_content(I18n.t(:name_error,
+            expect(page).to have_content(I18n.t(:active_record_record_not_found,
                                                 scope: [:services, :permissions, :create, :errors]))
           end
         end
@@ -90,22 +90,32 @@ describe 'visiting / service permissions' do
           let(:other_user) do
             User.find_or_create_by(name: 'Another test user', email: 'another_test@example.justice.gov.uk')
           end
+          let(:a_team) { Team.find_by_name('A Team') }
 
           before do
             visit "/services/#{service.slug}/permissions"
             select 'A Team', from: 'permission[team_id]'
           end
 
-          context 'when there is an authorisation error' do
-            let(:a_team) { Team.find_by_name('A Team') }
-
+          context 'when there is a Pundit authorisation error' do
             before do
               a_team.created_by_user = other_user
               a_team.save
               click_button(I18n.t('services.permissions.form.submit'))
             end
-            it 'displays the Pundit authorisation error message' do
+            it 'displays the error message' do
               expect(page).to have_content(I18n.t(:pundit_not_authorized_error,
+                                                  scope: [:services, :permissions, :create, :errors]))
+            end
+          end
+          context 'when there is a no record error' do
+            before do
+              a_team.delete
+              a_team.save
+            end
+            it 'displays the error message' do
+              click_button(I18n.t('services.permissions.form.submit'))
+              expect(page).to have_content(I18n.t(:name_error,
                                                   scope: [:services, :permissions, :create, :errors]))
             end
           end


### PR DESCRIPTION
We want users to be able to add teams quickly, without breaking the user journey to do so.