### PR TITLE
add submitter_url to env vars for a service

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -405,7 +405,9 @@ class KubernetesAdapter
             # read by the user data store in isolation
             env:
               - name: USER_DATASTORE_URL
-                value: #{@environment.user_datastore_url} 
+                value: #{@environment.user_datastore_url}
+              - name: SUBMITTER_URL
+                value: #{@environment.submitter_url}
               - name: SERVICE_SLUG
                 value: #{name}
               - name: SERVICE_TOKEN

--- a/app/value_objects/service_environment.rb
+++ b/app/value_objects/service_environment.rb
@@ -1,6 +1,7 @@
 class ServiceEnvironment
   attr_accessor :deployment_adapter, :kubectl_context, :name, :slug,
-                :namespace, :protocol, :url_root, :user_datastore_url
+                :namespace, :protocol, :url_root,
+                :user_datastore_url, :submitter_url
 
   def self.all
     Rails.configuration.x.service_environments.map do |key, values|

--- a/config/initializers/service_environments.rb
+++ b/config/initializers/service_environments.rb
@@ -6,7 +6,8 @@ ALL_ENVS = {
     namespace: 'formbuilder-services-dev',
     protocol: 'https://',
     url_root: 'apps.cloud-platform-live-0.k8s.integration.dsd.io',
-    user_datastore_url: 'http://fb-user-datastore-api-svc-dev.formbuilder-platform-dev/'
+    user_datastore_url: 'http://fb-user-datastore-api-svc-dev.formbuilder-platform-dev/',
+    submitter_url: 'http://fb-submitter-api-svc-dev.formbuilder-platform-dev/'
   },
   staging: {
     deployment_adapter: 'cloud_platform',
@@ -15,7 +16,8 @@ ALL_ENVS = {
     namespace: 'formbuilder-services-staging',
     protocol: 'https://',
     url_root: 'apps.cloud-platform-live-0.k8s.integration.dsd.io',
-    user_datastore_url: 'http://fb-user-datastore-api-svc-staging.formbuilder-platform-staging/'
+    user_datastore_url: 'http://fb-user-datastore-api-svc-staging.formbuilder-platform-staging/',
+    submitter_url: 'http://fb-submitter-api-svc-staging.formbuilder-platform-staging/'
   },
   production: {
     deployment_adapter: 'cloud_platform',
@@ -24,7 +26,8 @@ ALL_ENVS = {
     namespace: 'formbuilder-services-production',
     protocol: 'https://',
     url_root: 'apps.cloud-platform-live-0.k8s.integration.dsd.io',
-    user_datastore_url: 'http://fb-user-datastore-api-svc-production.formbuilder-platform-production/'
+    user_datastore_url: 'http://fb-user-datastore-api-svc-production.formbuilder-platform-production/',
+    submitter_url: 'http://fb-submitter-api-svc-production.formbuilder-platform-production/'
   }
 }
 # only use minikube on local machines - i.e. dev


### PR DESCRIPTION
To allow deployed services to submit their data to the submitter, they need to be told what URL to use for it.

This PR adds `submitter_url` to the service_environment and the list of env vars for a deployment.