### PR TITLE
Alert user when changing service slug that any user data held in the datastore will be lost

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -27,7 +27,8 @@ class ServicesController < ApplicationController
     end
   end
 
-  def edit
+  def edit_confirm
+    @service = Service.find_by_slug(service_params[:slug])
   end
 
   def destroy
@@ -36,10 +37,10 @@ class ServicesController < ApplicationController
   end
 
   def update
-    if @service.update(service_params)
-      redirect_to service_path(@service), notice: t(:success, scope: [:services, :update], service: @service.name)
-    else
-      render :edit
+    if params[:commit] == t('services.edit_confirm.confirm') || @service.slug == service_params[:slug]
+      redirect(@service, service_params)
+    elsif @service.slug != service_params[:slug]
+      render :edit_confirm
     end
   end
 
@@ -65,5 +66,13 @@ class ServicesController < ApplicationController
 
   def service_params
     params[:service].permit([:git_repo_url, :name, :slug])
+  end
+
+  def redirect(service, params)
+    if @service.update(params)
+      redirect_to service_path(service), notice: t(:success, scope: [:services, :update], service: @service.name)
+    else
+      render :edit
+    end
   end
 end

--- a/app/views/services/edit.html.haml
+++ b/app/views/services/edit.html.haml
@@ -4,4 +4,4 @@
 = GovukElementsErrorsHelper.error_summary @service,
   t(:errors_intro, scope: [:shared]), ''
 
-= render partial: 'services/form', locals: {service: @service, button_label: t('.form.submit')}
+= render partial: 'services/form', locals: {service: @service, button_label: t('.form.submit') }

--- a/app/views/services/edit_confirm.html.haml
+++ b/app/views/services/edit_confirm.html.haml
@@ -1,0 +1,12 @@
+%h1.heading-xlarge
+  = t('services.edit_confirm.heading', name: @service.name)
+
+%p.lede
+  = t('services.update.confirm')
+
+= form_for @service, method: :patch do |f|
+  = f.hidden_field :name, value: params[:service][:name]
+  = f.hidden_field :slug, value: params[:service][:slug]
+  = f.hidden_field :git_repo_url, value: params[:service][:git_repo_url]
+  = link_to t('services.edit_confirm.dismiss'), edit_service_path(@service), class: 'button button-cta'
+  = f.submit t('services.edit_confirm.confirm'), class: 'button button-cta'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,10 @@ en:
       success: Your new service has been created. You'll need to deploy your service to an environment to see it on the web.
     destroy:
       success: Service "%{service}" deleted successfully
+    edit_confirm:
+      heading: "Confirm slug change for service: %{name}"
+      confirm: 'Yes'
+      dismiss: 'No'
     edit:
       heading: Editing '%{name}'
       form:
@@ -228,6 +232,7 @@ en:
       url: URL
     update:
       success: Service "%{service}" updated successfully. You'll need to deploy your service for these changes to take effect on the web.
+      confirm: Are you sure you want to change the slug? Doing so will erase any 'user data' held in the User datastore.
   teams:
     create:
       success: Your new team has been created successfully


### PR DESCRIPTION
The service slug is used as part of the key to retrieve data from the user datastore, and also the first part of the domain to which the user's cookie will be scoped. So, changing the service slug on a service with live user data in, will render any existing data irretrievable.
<img width="821" alt="screen shot 2018-11-01 at 16 48 23" src="https://user-images.githubusercontent.com/10685841/47866756-8e5e3780-ddf7-11e8-8cc9-ab1498646070.png">
<img width="1029" alt="screen shot 2018-11-01 at 16 48 50" src="https://user-images.githubusercontent.com/10685841/47866775-9e761700-ddf7-11e8-9754-a07939b830b0.png">

