### PR TITLE
Page header improvements

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,0 +1,5 @@
+class HelpController < ApplicationController
+  def show
+
+  end
+end

--- a/app/views/help/show.html.haml
+++ b/app/views/help/show.html.haml
@@ -1,0 +1,20 @@
+%div.column-full
+  %h1.heading-xlarge
+    = t('help.heading')
+
+  %p.lede
+    = t('help.lede')
+  %ul.text.list.list-bullet
+    %li.lede
+      = t('help.name')
+    %li.lede
+      = t('help.json')
+  %p.lede.text
+    = t('help.publisher_tool')
+  %p.lede
+    = t('help.also')
+  %ul.text.list.list-bullet
+    %li.lede
+      = t('help.configure')
+    %li.lede
+      = t('help.assign')

--- a/app/views/layouts/_unsigned_user_nav.html.haml
+++ b/app/views/layouts/_unsigned_user_nav.html.haml
@@ -1,0 +1,5 @@
+%ul#proposition-links
+  %li
+    = link_to t('.help'), help_path
+  %li
+    = link_to t('.sign_in'), '/auth/auth0'

--- a/app/views/layouts/_user_nav.html.haml
+++ b/app/views/layouts/_user_nav.html.haml
@@ -6,5 +6,7 @@
   %li
     = link_to t('.profile'), edit_user_path
   %li
+    = link_to t('layouts.unsigned_user_nav.help'), help_path
+  %li
     .sign-out
       = button_to t('.sign_out'), user_session_path, method: :delete, class: 'styled-as-link'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,8 +27,11 @@
 
       %nav#proposition-menu
         = link_to t('.title'), root_url, id: 'proposition-name'
+
         - if current_user
           = render partial: 'layouts/user_nav'
+        - else
+          = render partial: 'layouts/unsigned_user_nav'
 
 = content_for :content do
   %main{ class: "content inner cf", id: "content", role: "main" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,7 +95,7 @@ en:
     login:
       link_text: Use your MoJ Google Account to sign in or sign up
     show:
-      heading: Welcome to MoJ Form Publisher
+      heading: 'Welcome to Form Builder: Publisher'
       lede_html:
         We're trialling a new service to let you publish
         <a href="%{link_url}">Form Specification</a> files
@@ -107,7 +107,7 @@ en:
   layouts:
     application:
       logo_link_title: Form Publisher home
-      title: "MoJ Form Publisher"
+      title: "Form Builder: Publisher"
     dev_tools:
       fake_login: Fake Login
     user_nav:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,17 @@ en:
     restarting: 'Restarting service'
     starting: 'Starting job %{job_id} for ServiceDeployment %{service_deployment_id}'
     writing_commit: 'Writing commit SHA %{sha}'
+  help:
+    heading: Help getting started
+    lede: "Having signed in to the tool using your justice.gov.uk email, you'll need to:"
+    name: name your form
+    json: enter where the form’s JSON files are stored in Github
+    publisher_tool:
+      This enables the publisher tool to create development, staging and live environments that you can deploy your form to.
+    also: 'You can also choose to:'
+    configure:
+      configure environments by adding Google Analytics, tracking IDs, passwords and IDs
+    assign: assign permissions for individual team members
   home:
     login:
       link_text: Use your MoJ Google Account to sign in or sign up
@@ -115,6 +126,9 @@ en:
       services: Services
       sign_out: Sign out
       teams: Teams
+    unsigned_user_nav:
+      help: Help
+      sign_in: Sign in
   phase_banner:
     content_html:
       This is a new service - your <a href="%{link_url}">feedback</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   get '/dashboard' => 'dashboard#show'
   get '/welcome' => 'welcome#show'
+  get '/help' => 'help#show'
   get '/signup_not_allowed' => 'user_sessions#signup_not_allowed', as: 'signup_not_allowed'
   get '/signup_error/:error_type' => 'user_sessions#signup_error', as: 'signup_error'
   get '/' => 'home#show', as: 'root'

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe HelpController do
+  describe '#show' do
+    context 'for any user, signed in or not' do
+      it 'returns 200 OK' do
+        get :show
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/features/require_user_spec.rb
+++ b/spec/features/require_user_spec.rb
@@ -13,6 +13,14 @@ describe 'visiting the home page' do
     it 'shows a link to login' do
       expect(page).to have_link(I18n.t(:link_text, scope: [:home, :login]))
     end
+
+    it 'shows a link for help' do
+      expect(page).to have_link(I18n.t(:help, scope: [:layouts, :unsigned_user_nav]))
+    end
+
+    it 'shows a link to sign in' do
+      expect(page).to have_link(I18n.t(:sign_in, scope: [:layouts, :unsigned_user_nav]))
+    end
   end
 
   context 'as a logged in user' do
@@ -23,6 +31,14 @@ describe 'visiting the home page' do
 
     it 'does not show a link to login' do
       expect(page).to_not have_link(I18n.t(:link_text, scope: [:home, :login]))
+    end
+
+    it 'does not show a link to sign in' do
+      expect(page).to_not have_link(I18n.t(:sign_in, scope: [:layouts, :unsigned_user_nav]))
+    end
+
+    it 'shows a link for help' do
+      expect(page).to have_link(I18n.t(:help, scope: [:layouts, :unsigned_user_nav]))
     end
   end
 end


### PR DESCRIPTION
 - Update the product name, change "MoJ Form Publisher" to "Form Builder: Publisher"

- Add a "Help" link and create a page entitled "Help getting started". This link should be available in the header from the landing page (available to both unsigned in users and signed in users).

- Add Sign In link to navigation

### Before:
**Home page (user not logged in)**
<img width="1021" alt="screen shot 2018-11-09 at 17 12 20" src="https://user-images.githubusercontent.com/10685841/48278122-87ad7100-e444-11e8-9f45-874f6c34094a.png">

**Logged in**
<img width="999" alt="screen shot 2018-11-09 at 17 12 02" src="https://user-images.githubusercontent.com/10685841/48278126-8e3be880-e444-11e8-8d72-8cfbafcbd856.png">

### After:
**Help page**
<img width="815" alt="screen shot 2018-11-09 at 16 38 47" src="https://user-images.githubusercontent.com/10685841/48278137-98f67d80-e444-11e8-96e3-90a4c6d7a34e.png">

**Logged in**
<img width="917" alt="screen shot 2018-11-09 at 16 39 24" src="https://user-images.githubusercontent.com/10685841/48278149-a0b62200-e444-11e8-920e-afe0cfe29ddd.png">

