### PR TITLE
Add functionality to delete the current form/service from within the page

### DIFF
--- a/app/assets/stylesheets/services.scss
+++ b/app/assets/stylesheets/services.scss
@@ -27,3 +27,7 @@
     width: 20%;
   }
 }
+
+.warning, .warning:visited {
+  background-color: $red;
+}

--- a/app/views/services/_remove.html.haml
+++ b/app/views/services/_remove.html.haml
@@ -1,0 +1,16 @@
+%br
+%div.notice
+  %i.icon.icon-important
+    %span.visually-hidden
+      = 'Warning'
+  %strong.bold-small
+    = t('services.show.warning')
+%div
+  %br
+    %p.lede
+      = link_to t('services.show.delete'),
+            service_path(service),
+            class: 'button warning',
+            method: :delete,
+            data: { confirm: t('services.service.delete_confirm', service: service.name),
+                    disable_with: t('services.service.deleting') }

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -19,3 +19,4 @@
 
   %tbody
     = render partial: 'environment', collection: @status_by_environment
+= render partial: 'remove', locals: {service: @service }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -240,9 +240,11 @@ en:
       edit: Edit
       success: The service "%{service}" was successfully deleted
     show:
+      delete: Delete form
       lede_html:
         Status of your service in the available environments
       timestamp: Checked at
+      warning: Deleted forms cannot be restored. You cannot undo this action.
       url: URL
     update:
       success: Service "%{service}" updated successfully. You'll need to deploy your service for these changes to take effect on the web.

--- a/spec/features/service_status_spec.rb
+++ b/spec/features/service_status_spec.rb
@@ -10,6 +10,46 @@ describe 'viewing service status' do
     login_as!(user)
   end
 
+  describe 'deleting the service' do
+    before do
+      visit "/services/#{service.slug}"
+    end
+
+    it 'has a delete button' do
+      expect(page).to have_link(I18n.t(:delete, scope: [:services, :show]))
+    end
+
+    it 'has warning text for the delete button' do
+      expect(page).to have_content(I18n.t(:warning, scope: [:services, :show]))
+    end
+
+    context "clicking 'Delete form'", js: true do
+      let(:message) do
+        accept_confirm do
+          click_on(I18n.t(:delete, scope: [:services, :show]))
+        end
+      end
+
+      before do
+        message
+      end
+
+      it 'displays a confirmation alert pop-up' do
+        expect(message).to eq("Are you sure you want to delete the service '#{service.name}'?")
+      end
+
+      it 'successfully deletes the form' do
+        expect(page).to have_content(I18n.t(:success, scope: [:services, :destroy], service: service.name))
+      end
+
+      it "returns user to 'Your forms' page" do
+        within('#content') do
+          expect(page).to have_content(I18n.t(:heading, scope: [:services, :index]))
+        end
+      end
+    end
+  end
+
   describe 'no service status checks' do
     context 'with no completed deployments' do
       before do


### PR DESCRIPTION
**Before:**

<img width="1301" alt="screen shot 2018-11-14 at 13 57 26" src="https://user-images.githubusercontent.com/10685841/48487230-7d5cef80-e815-11e8-83a1-f91287a6ded5.png">

**After:**

<img width="1313" alt="screen shot 2018-11-14 at 13 55 07" src="https://user-images.githubusercontent.com/10685841/48487237-851c9400-e815-11e8-8b78-cd09f9a40d7c.png">
