### PR TITLE
Improve UI around delete button

### DIFF
--- a/app/assets/stylesheets/services.scss
+++ b/app/assets/stylesheets/services.scss
@@ -35,3 +35,11 @@
 .pad-bottom {
   padding-bottom: 1.1em;
 }
+
+.pad-top {
+  padding-top: 2.6em;
+}
+
+.pad-top-small {
+  padding-top: 0.8em;
+}

--- a/app/views/services/_remove.html.haml
+++ b/app/views/services/_remove.html.haml
@@ -1,16 +1,16 @@
-%br
-%div.notice
-  %i.icon.icon-important
-    %span.visually-hidden
-      = 'Warning'
-  %strong.bold-small
-    = t('services.show.warning')
-%div
-  %br
-    %p.lede
-      = link_to t('services.show.delete'),
-            service_path(service),
-            class: 'button warning',
-            method: :delete,
-            data: { confirm: t('services.service.delete_confirm', service: service.name),
-                    disable_with: t('services.service.deleting') }
+%div.pad-top
+  %div.notice
+    %i.icon.icon-important
+      %span.visually-hidden
+        = 'Warning'
+    %strong.bold-small
+      = t(:warning_html, scope: [:services, :show], git_repo_url: service.git_repo_url)
+  %div
+    %br
+      %p.pad-top-small
+        = link_to t('services.show.delete'),
+              service_path(service),
+              class: 'button warning',
+              method: :delete,
+              data: { confirm: t('services.service.delete_confirm', service: service.name),
+                      disable_with: t('services.service.deleting') }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,7 +248,7 @@ en:
       lede_html:
         Status of your service in the available environments
       timestamp: Checked at
-      warning: Deleted forms cannot be restored. You cannot undo this action.
+      warning_html: Clicking delete removes the form from the publisher - you can still <a href='%{git_repo_url}'>access the form’s data</a>
       url: URL
     update:
       success: Service "%{service}" updated successfully. You'll need to deploy your service for these changes to take effect on the web.

--- a/spec/features/service_status_spec.rb
+++ b/spec/features/service_status_spec.rb
@@ -19,8 +19,8 @@ describe 'viewing service status' do
       expect(page).to have_link(I18n.t(:delete, scope: [:services, :show]))
     end
 
-    it 'has warning text for the delete button' do
-      expect(page).to have_content(I18n.t(:warning, scope: [:services, :show]))
+    it "has a link to the form's git repo" do
+      expect(page).to have_selector("a[href='#{service.git_repo_url}']")
     end
 
     context "clicking 'Delete form'", js: true do


### PR DESCRIPTION
Decrease delete button size
Increase clearance area around the warning component
Replace the copy for the delete warning text

***Before:***
<img width="1064" alt="screen shot 2018-11-29 at 10 41 53" src="https://user-images.githubusercontent.com/10685841/49216814-e28f1400-f3c3-11e8-998f-4516db6d2025.png">

***After:***
<img width="1069" alt="screen shot 2018-11-29 at 10 37 02" src="https://user-images.githubusercontent.com/10685841/49216852-faff2e80-f3c3-11e8-9456-a745749ccc41.png">

