### PR TITLE
Validate user generated slugs

### DIFF
--- a/app/models/concerns/has_slug.rb
+++ b/app/models/concerns/has_slug.rb
@@ -5,7 +5,7 @@ module Concerns
     extend ActiveSupport::Concern
 
     included do
-      validates :slug, format: { with: /\A[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\z/,
+      validates :slug, format: { with: /\A[a-z0-9]+([-.a-z0-9]?[a-z0-9])*[a-z0-9]*\z/,
                                  message: I18n.t('errors.service.slug.invalid')},
                        uniqueness: true,
                        length: { maximum: 64, minimum: 3 }

--- a/app/models/concerns/has_slug.rb
+++ b/app/models/concerns/has_slug.rb
@@ -5,9 +5,12 @@ module Concerns
     extend ActiveSupport::Concern
 
     included do
-      validates :slug, length: {maximum: 64, minimum: 3}, uniqueness: true
+      validates :slug, format: { with: /\A[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\z/,
+                                 message: I18n.t('errors.service.slug.invalid')},
+                       uniqueness: true,
+                       length: { maximum: 64, minimum: 3 }
       before_validation :generate_slug_if_blank!
-      
+
       def to_param
         slug
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,8 @@ en:
       git_repo_url:
         not_valid_scheme: "must be a valid https: or file: URL"
         invalid_uri: "is not a valid https: or file: URL"
+      slug:
+        invalid: "is invalid (can only contain lower case letters or numbers, '-' or '.', and must start and end with a letter or number)"
   helpers:
     hint:
       service:

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -49,10 +49,10 @@ describe Service do
 
     context 'with an empty slug' do
       before do
-        subject.slug = ""
+        subject.slug = ''
       end
       it 'populates slug' do
-        expect{ subject.valid? }.to change(subject, :slug).from("")
+        expect{ subject.valid? }.to change(subject, :slug).from('')
       end
       describe 'the resulting slug' do
         before do
@@ -68,91 +68,107 @@ describe Service do
 
     context 'with a user generated slug' do
       describe 'with invalid slug' do
-        context 'when the slug contains capital letters' do
-          before do
+        describe 'when the slug contains capital letters' do
+          it 'adds an error on slug' do
             subject.slug = 'aCaptialLetter'
-          end
-
-          it 'adds an error on slug' do
             subject.valid?
-            expect(subject.errors[:slug]).to_not be_empty
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
           end
         end
 
-        context 'when the slug contains spaces' do
-          before do
+        describe 'when the slug contains consecutive hypens' do
+          it 'adds an error on slug' do
+            subject.slug = 'apply----for-a-license'
+            subject.valid?
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
+          end
+        end
+
+        describe 'when the slug contains consecutive dots' do
+          it 'adds an error on slug' do
+            subject.slug = 'apply....for-a-license'
+            subject.valid?
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
+          end
+        end
+
+        describe 'when the slug contains a combination of consecutive dots and hypens' do
+          it 'adds an error on slug' do
+            subject.slug = 'apply.-.-.for-a-license'
+            subject.valid?
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
+          end
+        end
+
+        describe 'when the slug contains spaces' do
+          it 'adds an error on slug' do
             subject.slug = 'apply for a license'
-          end
-
-          it 'adds an error on slug' do
             subject.valid?
-            expect(subject.errors[:slug]).to_not be_empty
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
           end
         end
 
-        context "when the slug contains a symbol '@'" do
-          before do
+        describe "when the slug contains symbols '@'" do
+          it 'adds an error on slug' do
             subject.slug = '99-problems@'
-          end
-
-          it 'adds an error on slug' do
             subject.valid?
-            expect(subject.errors[:slug]).to_not be_empty
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
           end
         end
 
-        context "when the slugs first character is '-'" do
-          before do
+        describe "when the slugs first character is '-'" do
+          it 'adds an error on slug' do
             subject.slug = '-apply-for-a-license'
-          end
-
-          it 'adds an error on slug' do
             subject.valid?
-            expect(subject.errors[:slug]).to_not be_empty
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
           end
         end
 
-        context "when the slugs last character is'-'" do
-          before do
+        describe "when the slugs last character is'-'" do
+          it 'adds an error on slug' do
             subject.slug = 'apply-for-a-license-'
-          end
-
-          it 'adds an error on slug' do
             subject.valid?
-            expect(subject.errors[:slug]).to_not be_empty
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
           end
         end
 
-        context "when the slug contains the character '_'" do
-          before do
-            subject.slug = '.apply_for_a_license'
-          end
-
+        describe "when the slugs last character is'.'" do
           it 'adds an error on slug' do
+            subject.slug = 'apply-for-a-license.'
             subject.valid?
-            expect(subject.errors[:slug]).to_not be_empty
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
+          end
+        end
+
+        describe "when the slug contains the character '_'" do
+          it 'adds an error on slug' do
+            subject.slug = '.apply_for_a_license'
+            subject.valid?
+            expect(subject.errors[:slug]).to include(I18n.t('errors.service.slug.invalid'))
           end
         end
       end
 
       describe 'with a valid slug' do
-        context 'when the slug only contains lowercase letters and hypens' do
-          before do
-            subject.slug = 'apply-for-a-license-to-do-something'
-          end
-
+        describe 'when the slug only contains lowercase letters and hypens' do
           it 'does not add an error on the slug' do
+            subject.slug = 'apply-for-a-license-to-do-something'
             subject.valid?
             expect(subject.errors[:slug]).to be_empty
           end
         end
 
-        context "when the slug contains the character '.' " do
-          before do
-            subject.slug = 'example.com'
-          end
-
+        describe 'when the slug contains letters, a hypen and a number' do
           it 'does not add an error on the slug' do
+            subject.slug = 'license-1'
+            subject.valid?
+            expect(subject.errors[:slug]).to be_empty
+          end
+        end
+
+        describe "when the slug contains the character '.' " do
+          it 'does not add an error on the slug' do
+            subject.slug = 'example.com'
             subject.valid?
             expect(subject.errors[:slug]).to be_empty
           end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -41,6 +41,7 @@ describe Service do
       end
     end
   end
+
   describe 'validation' do
     before do
       subject.name = "Apply for a license to do something"
@@ -61,6 +62,100 @@ describe Service do
 
         it 'equals to_slug(name)' do
           expect(slug).to eq(subject.send(:to_slug, subject.name))
+        end
+      end
+    end
+
+    context 'with a user generated slug' do
+      describe 'with invalid slug' do
+        context 'when the slug contains capital letters' do
+          before do
+            subject.slug = 'aCaptialLetter'
+          end
+
+          it 'adds an error on slug' do
+            subject.valid?
+            expect(subject.errors[:slug]).to_not be_empty
+          end
+        end
+
+        context 'when the slug contains spaces' do
+          before do
+            subject.slug = 'apply for a license'
+          end
+
+          it 'adds an error on slug' do
+            subject.valid?
+            expect(subject.errors[:slug]).to_not be_empty
+          end
+        end
+
+        context "when the slug contains a symbol '@'" do
+          before do
+            subject.slug = '99-problems@'
+          end
+
+          it 'adds an error on slug' do
+            subject.valid?
+            expect(subject.errors[:slug]).to_not be_empty
+          end
+        end
+
+        context "when the slugs first character is '-'" do
+          before do
+            subject.slug = '-apply-for-a-license'
+          end
+
+          it 'adds an error on slug' do
+            subject.valid?
+            expect(subject.errors[:slug]).to_not be_empty
+          end
+        end
+
+        context "when the slugs last character is'-'" do
+          before do
+            subject.slug = 'apply-for-a-license-'
+          end
+
+          it 'adds an error on slug' do
+            subject.valid?
+            expect(subject.errors[:slug]).to_not be_empty
+          end
+        end
+
+        context "when the slug contains the character '_'" do
+          before do
+            subject.slug = '.apply_for_a_license'
+          end
+
+          it 'adds an error on slug' do
+            subject.valid?
+            expect(subject.errors[:slug]).to_not be_empty
+          end
+        end
+      end
+
+      describe 'with a valid slug' do
+        context 'when the slug only contains lowercase letters and hypens' do
+          before do
+            subject.slug = 'apply-for-a-license-to-do-something'
+          end
+
+          it 'does not add an error on the slug' do
+            subject.valid?
+            expect(subject.errors[:slug]).to be_empty
+          end
+        end
+
+        context "when the slug contains the character '.' " do
+          before do
+            subject.slug = 'example.com'
+          end
+
+          it 'does not add an error on the slug' do
+            subject.valid?
+            expect(subject.errors[:slug]).to be_empty
+          end
         end
       end
     end

--- a/spec/services/deployment_service_spec.rb
+++ b/spec/services/deployment_service_spec.rb
@@ -337,7 +337,7 @@ describe DeploymentService do
   describe '.last_successful_deployment' do
     let(:user) { User.find_or_create_by(name: 'test user', email: 'test@example.justice.gov.uk') }
     let(:service) do
-      Service.create!(name: 'test', slug: 'Test', git_repo_url: 'https://github.com/some-org/some-repo.git',
+      Service.create!(name: 'test', slug: 'test', git_repo_url: 'https://github.com/some-org/some-repo.git',
                       created_by_user: user)
     end
 


### PR DESCRIPTION
The cloud platform will only accept slugs that consist of the following: lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.

This change now alerts the user when they enter a slug that is not valid:
<img width="870" alt="screen shot 2018-11-30 at 17 13 49" src="https://user-images.githubusercontent.com/10685841/49305920-9679c780-f4c8-11e8-87af-996cfbb6bb6a.png">
