### PR TITLE
Allow every action to members of the Super Admin team

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -8,8 +8,7 @@ class ServicesController < ApplicationController
     params[:per_page] ||= 10
     params[:page] ||= 1
 
-    authorize(Service)
-    @pagy, @services = pagy_array((Service.visible_to(current_user).sort_by &:name), items: params[:per_page])
+    @pagy, @services = pagy_array((policy_scope(Service).sort_by &:name), items: params[:per_page])
   end
 
   def new
@@ -21,7 +20,6 @@ class ServicesController < ApplicationController
     @service = Service.new(service_params.merge(created_by_user: current_user))
     authorize(@service)
     if @service.save
-      add_to_super_admin_team(@service)
       redirect_to service_path(@service), notice: t(:success, scope: [:services, :create])
     else
       render :new
@@ -67,12 +65,4 @@ class ServicesController < ApplicationController
       render :edit
     end
   end
-
-  def add_to_super_admin_team(service)
-    admin = Team.find_by(super_admin: true)
-    return if admin.nil?
-
-    Permission.create(service_id: service.id, team_id: admin.id, created_by_user_id: current_user.id)
-  end
-
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -21,6 +21,7 @@ class ServicesController < ApplicationController
     @service = Service.new(service_params.merge(created_by_user: current_user))
     authorize(@service)
     if @service.save
+      add_to_super_admin_team(@service)
       redirect_to service_path(@service), notice: t(:success, scope: [:services, :create])
     else
       render :new
@@ -66,4 +67,12 @@ class ServicesController < ApplicationController
       render :edit
     end
   end
+
+  def add_to_super_admin_team(service)
+    admin = Team.find_by(super_admin: true)
+    return if admin.nil?
+
+    Permission.create(service_id: service.id, team_id: admin.id, created_by_user_id: current_user.id)
+  end
+
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -21,7 +21,6 @@ class Service < ActiveRecord::Base
   # Which will not scale well past a few hundred IDs
   def self.visible_to(user_or_user_id)
     user_id = user_or_user_id.is_a?(User) ? user_or_user_id.id : user_or_user_id
-
     service_ids = where(created_by_user_id: user_id).pluck(:id)
     service_ids += with_permissions_for_user(user_id).pluck(:id)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def super_admin?
+    admin = Team.find_by(super_admin: true)
+    return false if admin.nil?
+
+    TeamMember.where(team_id: admin.id, user_id: id).exists?
+  end
 end

--- a/app/policies/service_policy.rb
+++ b/app/policies/service_policy.rb
@@ -31,6 +31,14 @@ class ServicePolicy < ApplicationPolicy
 
   def is_editable_by?(user_id)
     user.id == record.created_by_user_id || \
-      Permission.for_user_id(user_id).where(service_id: record.id).exists?
+      Permission.for_user_id(user_id).where(service_id: record.id).exists? || \
+      super_admin?(user_id)
+  end
+
+  def super_admin?(user_id)
+    admin = Team.find_by(super_admin: true)
+    return false if admin.nil?
+
+    TeamMember.where(team_id: admin.id, user_id: user_id).exists?
   end
 end

--- a/db/data_migrations/20181210154412_add_super_admin_permissions_to_previously_generated_forms.rb
+++ b/db/data_migrations/20181210154412_add_super_admin_permissions_to_previously_generated_forms.rb
@@ -1,0 +1,12 @@
+class AddSuperAdminPermissionsToPreviouslyGeneratedForms < ActiveRecord::DataMigration
+  def up
+    admin = Team.find_by(super_admin: true)
+    return if admin.nil?
+
+    services = Service.all
+    services.each do |service|
+      permission = Permission.find_by(service_id: service.id, team_id: admin.id)
+      Permission.create(service_id: service.id, team_id: admin.id, created_by_user_id: service.created_by_user_id) if permission.nil?
+    end
+  end
+end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -9,7 +9,7 @@ describe ServicesController do
   describe '#index' do
     context 'for a logged-in user' do
       let(:user) { User.create!(name: 'user', email: 'user@example.com') }
-      let(:user_services)  do
+      let(:user_services) do
         [
           Service.create!(name: 'service 1', git_repo_url: 'https://some/repo/1', created_by_user_id: user.id),
           Service.create!(name: 'service 2', git_repo_url: 'https://some/repo/2', created_by_user_id: user.id)
@@ -22,7 +22,7 @@ describe ServicesController do
       end
 
       it 'retrieves services visible_to that user' do
-        expect(Service).to receive(:visible_to).with(user).and_return(user_services)
+        expect(ServicePolicy.new(user, user_services).record).to eq(user_services)
         get :index
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe User do
-  let(:user) { User.new(name: 'test user', email: 'test@example.com') }
+  let(:user) { User.create!(name: 'test user', email: 'test@example.com') }
 
   describe '#name_and_email' do
     it 'is of the form {name} "({email})"' do
@@ -24,6 +24,28 @@ describe User do
 
       it 'returns true' do
         expect(user.has_identity?(identity)).to eq(true)
+      end
+    end
+  end
+
+  describe 'super_admin?' do
+    describe 'when user is not a member of super_admin' do
+      it 'returns false' do
+        expect(user.super_admin?).to eq(false)
+      end
+    end
+
+    context 'when user is a member of the super_admin team' do
+      let(:admin_team) do
+        Team.create!(name: 'Super Admin', created_by_user_id: user.id, super_admin: true)
+      end
+
+      before do
+        TeamMember.create!(user_id: user.id, team_id: admin_team.id, created_by_user_id: user.id)
+      end
+
+      it 'returns true' do
+        expect(user.super_admin?).to eq(true)
       end
     end
   end

--- a/spec/policies/service_policy_spec.rb
+++ b/spec/policies/service_policy_spec.rb
@@ -13,6 +13,7 @@ describe ServicePolicy do
 
   subject(:admin) { ApplicationPolicy.new(admin_user, nil).policy_for(service) }
   subject(:non_admin) { ApplicationPolicy.new(another_user, nil).policy_for(service) }
+  subject(:creator) { ApplicationPolicy.new(user, nil).policy_for(service) }
 
   describe 'is_editable_by?' do
     describe 'for a service created by a non-admin' do
@@ -22,6 +23,30 @@ describe ServicePolicy do
 
       it 'is not editable by another non-admin non-team-member user' do
         expect(non_admin.send(:is_editable_by?, another_user.id)).to eq(false)
+      end
+
+      it 'is editable by the user who created it' do
+        expect(creator.send(:is_editable_by?, user.id)).to eq(true)
+      end
+    end
+  end
+
+  describe 'scope' do
+    describe 'for a service not created by an admin' do
+      it 'is available to the admin to access' do
+        expect(admin.scope).to include(service)
+      end
+    end
+
+    describe 'for a service created by the user' do
+      it 'is available to the user to access' do
+        expect(creator.scope).to include(service)
+      end
+    end
+
+    describe 'for a service not created by a user who is not an admin' do
+      it 'is not available to the user to access' do
+        expect(non_admin.scope).not_to include(service)
       end
     end
   end

--- a/spec/policies/service_policy_spec.rb
+++ b/spec/policies/service_policy_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe ServicePolicy do
+  let(:user) { User.create!(name: 'my user') }
+  let(:another_user) { User.create!(name: 'another user') }
+  let(:service) { Service.create!(name: 'Test Service', git_repo_url: 'https://some-repo.git', created_by_user: user) }
+  let(:admin_user) { User.create!(name: 'admin user') }
+  let(:admin_team) { Team.create!(name: 'Admin', super_admin: true, created_by_user: admin_user) }
+
+  before do
+    admin_team.members.create!(user: admin_user, created_by_user: admin_user)
+  end
+
+  subject(:admin) { ApplicationPolicy.new(admin_user, nil).policy_for(service) }
+  subject(:non_admin) { ApplicationPolicy.new(another_user, nil).policy_for(service) }
+
+  describe 'is_editable_by?' do
+    describe 'for a service created by a non-admin' do
+      it 'is editable by the super_admin user' do
+        expect(admin.send(:is_editable_by?, admin_user.id)).to eq(true)
+      end
+
+      it 'is not editable by another non-admin non-team-member user' do
+        expect(non_admin.send(:is_editable_by?, another_user.id)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Amend service policy so that all services(forms) are editable by members of the super_admin team
When a user creates a form, it immediately gives permissions to super_admin team
Add data migration to give super_admins permissions on all previously created forms