### PR TITLE
Filter view by form name

### DIFF
--- a/app/assets/stylesheets/services.scss
+++ b/app/assets/stylesheets/services.scss
@@ -43,3 +43,7 @@
 .pad-top-small {
   padding-top: 0.8em;
 }
+
+.right-align {
+  text-align: right;
+}

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -8,7 +8,10 @@ class ServicesController < ApplicationController
     params[:per_page] ||= 10
     params[:page] ||= 1
 
-    @pagy, @services = pagy_array((policy_scope(Service).sort_by &:name), items: params[:per_page])
+    filter_service = policy_scope(Service).contains(filter_params[:query]).sort_by &:name
+    filter_service = policy_scope(Service).sort_by &:name if filter_service.empty?
+
+    @pagy, @services = pagy_array(filter_service, items: params[:per_page])
   end
 
   def new
@@ -56,6 +59,10 @@ class ServicesController < ApplicationController
 
   def service_params
     params[:service].permit([:git_repo_url, :name, :slug])
+  end
+
+  def filter_params
+    params.permit([:query])
   end
 
   def redirect(service, params)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -16,6 +16,8 @@ class Service < ActiveRecord::Base
 
   before_validation :ensure_token_is_present
 
+  scope :contains, -> (name) { where("lower(name) like ?", "%#{name}%".downcase)}
+
   # NOTE: uses same naive implementation as Team.visible_to -
   # two separate queries for IDs, then a single WHERE id IN(?)
   # Which will not scale well past a few hundred IDs

--- a/app/views/services/_filter.html.haml
+++ b/app/views/services/_filter.html.haml
@@ -1,0 +1,4 @@
+= form_tag(services_path, method: :get) do
+  = label_tag I18n.t('services.filter.label')
+  = text_field_tag :query, params[:query], class: 'form-control'
+  = submit_tag I18n.t('services.filter.submit'), class: 'button button-cta', name: nil

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -3,10 +3,10 @@
     = t('.heading')
 
 %div.grid-row.pad-bottom
-  %div.column-two-thirds
-    = link_to t('.new_service'), new_service_path, class: 'button button-cta'
   %div.column-one-third
-    %p
+    = link_to t('.new_service'), new_service_path, class: 'button button-cta'
+  %div.column-two-thirds.right-align
+    = render partial: 'filter'
 
 - if @services.empty?
   %p
@@ -20,4 +20,5 @@
         = t('.actions')
     %tbody
       = render partial: 'service', collection: @services
+%div.pad-top
 = pagy_nav(@pagy).html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,6 +200,9 @@ en:
       checking: 'checking...'
       check_now: 'Check now'
       no_deployment: 'Not yet deployed'
+    filter:
+      label: 'Filter by form name:'
+      submit: Filter
     form:
       token: Secret token (click to show/regenerate)
     index:

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -318,4 +318,20 @@ describe Service do
       end
     end
   end
+
+  describe '.contains' do
+    let(:user) { User.create!(name: 'test user', email: 'test@example.com') }
+    let(:other_user) { User.create!(name: 'Other User', email: 'otheruser@example.com') }
+    let(:example_service) { Service.create(name: 'Example', git_repo_url: 'https://some/repo', created_by_user: user) }
+    let(:user_service) { Service.create(name: 'Test Service', git_repo_url: 'https://some/repo', created_by_user: user) }
+    let(:deed_poll_service) { Service.create(name: 'Deed Poll', git_repo_url: 'https://some/repo', created_by_user: user) }
+
+    it "returns any services name that contains the word 'test'" do
+      expect(Service.contains('test')).to include(user_service)
+    end
+
+    it 'returns an empty record if an empty string is entered' do
+      expect(Service.contains('')).eql?([])
+    end
+  end
 end


### PR DESCRIPTION
All users are able to filter forms by name. The returned list will only show forms that the user is allowed to view. The filter is case-insensitive and will match if the string is contained within the form name.

In addition padding has been added to pagination


<img width="1236" alt="screen shot 2018-12-17 at 16 00 25" src="https://user-images.githubusercontent.com/10685841/50099344-cab5ed80-0215-11e9-8ca3-ff75323d1403.png">
