### PR TITLE
A user with no permissions on a service/form should not be able to access it

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,9 +6,20 @@ class ApplicationController < ActionController::Base
   before_action :identify_user
   around_action :set_time_zone, if: :current_user
 
+  rescue_from Pundit::Error, with: :pundit_errors
+
   private
 
   def set_time_zone(&block)
     Time.use_zone(current_user.timezone, &block)
+  end
+
+  def pundit_errors(e)
+    scope = %i[errors pundit]
+    flash[:error] = I18n.t(e.class.name.underscore.gsub('/', '_'),
+                           scope: scope, message: e.class.name.underscore,
+                           default: I18n.t(:default, scope: scope))
+
+    redirect_to(request.referrer || root_path)
   end
 end

--- a/app/policies/service_policy.rb
+++ b/app/policies/service_policy.rb
@@ -8,7 +8,7 @@ class ServicePolicy < ApplicationPolicy
   end
 
   def show?
-    true
+    is_editable_by?(user.id)
   end
 
   def edit?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,10 @@
 
 en:
   errors:
+    pundit:
+      pundit_not_authorized_error: You are not authorised to perform this action
+      pundit_not_defined_error: The action you requested could not be found
+      default: Something went wrong %{message}
     service:
       git_repo_url:
         not_valid_scheme: "must be a valid https: or file: URL"
@@ -267,7 +271,6 @@ en:
       success: Team "%{team}" deleted successfully
     edit:
       heading: Editing '%{name}'
-
     environment:
       checking: 'checking...'
       check_now: 'Check now'
@@ -341,7 +344,6 @@ en:
         failed_retryable: Failed (retrying)
         failed_non_retryable: Failed
         queued: Queued
-
   user_sessions:
     destroy:
       success: "Signed out successfully"

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -354,5 +354,43 @@ describe 'visiting /services' do
         end
       end
     end
+
+    context 'accessing a form via url that you do not have permissions to view' do
+      let(:other_user) {User.create(name: 'other user', email: 'other_user@example.justice.gov.uk') }
+      let(:other_service) do
+        Service.create(name: 'Leavers Form',
+                       git_repo_url: 'https://some-repo.git',
+                       created_by_user: other_user)
+      end
+      before do
+        visit "/services/#{other_service.slug}"
+      end
+
+      it 'redirects user to services index page' do
+        within('h1') do
+          expect(page).to have_content(I18n.t(:heading, scope: [:services, :index]))
+        end
+      end
+
+      it 'displays an error alert message' do
+        expect(page).to have_content(I18n.t(:pundit_not_authorized_error, scope: [:errors, :pundit]))
+      end
+    end
+
+    describe 'entering a form name via url that does not exist' do
+      before do
+        visit '/services/a-non-existent-form'
+      end
+
+      it 'redirects user to services index page' do
+        within('h1') do
+          expect(page).to have_content(I18n.t(:heading, scope: [:services, :index]))
+        end
+      end
+
+      it 'displays an error alert message' do
+        expect(page).to have_content(I18n.t(:pundit_not_defined_error, scope: [:errors, :pundit]))
+      end
+    end
   end
 end


### PR DESCRIPTION
Services show page uses Pundit to determine if user has rights to view form.

Add appropriate Pundit error messages for 'NotAuthorized' and 'NotDefined' and return
user to the page they came from or the root_path

***Error message if form does not exist***
<img width="1090" alt="screen shot 2018-12-20 at 09 32 59" src="https://user-images.githubusercontent.com/10685841/50277031-4e045880-043b-11e9-9346-520ccec2dfa8.png">


***Error message if user not authorised to view***
<img width="1103" alt="screen shot 2018-12-20 at 09 33 20" src="https://user-images.githubusercontent.com/10685841/50277036-52307600-043b-11e9-9d9a-74bc8f754d33.png">
