### PR TITLE
Amend 'Create form page'

### DIFF
--- a/app/views/services/new.html.haml
+++ b/app/views/services/new.html.haml
@@ -1,7 +1,7 @@
 %h1.heading-xlarge
   = t('.heading')
 
-%p.lede
+%h2.heading-medium
   = t('.lede_html')
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,14 +47,13 @@ en:
     hint:
       service:
         git_repo_url_html:
-          This must use the <strong>https</strong> scheme (<em>not</em> ssh)<br />
-          For example, <a href="https://github.com/ministryofjustice/fb-sample-json.git">https://github.com/ministryofjustice/fb-sample-json.git</a>
+          Use full URL where the JSON files of your form are saved - for example, <br />
+          https://github.com/ministryofjustice/fb-sample-json.git
         name_html:
-          What users will see as the title of your service<br />
-          Must be 3-128 characters long. You can use any valid Unicode characters<br />
-          Check the <a href="https://www.gov.uk/service-manual/design/naming-your-service#how-to-name-your-service">Government Service Manual guidance on How to name your service</a>
+          Name must be 3-128 characters, no full stops, unique to publisher tool,  <br />
+          only used in the tool, not visible to users
         slug_html:
-          <em>(optional)</em> This will form the first part of your services' initial URL.<br />
+          <em>(optional)</em> This will form the first part of your forms' initial URL.<br />
           Must contain 3-64 characters, and only letters, numbers and hyphens (-)<br />
           Must be unique. If you leave this blank, we'll generate one for you
         token_html:
@@ -75,9 +74,9 @@ en:
           of the repository shown above, please enter the relative path to it here.
     label:
       service:
-        git_repo_url: URL of the service config JSON Git repository
-        name: Service name
-        slug: Service "slug"
+        git_repo_url: GitHub repository location
+        name: Form name
+        slug: Form "slug"
         token: Secret token
       service_deployment:
         commit_sha: Commit SHA, branch, or tag
@@ -223,7 +222,7 @@ en:
     new:
       heading: Create form
       lede_html:
-        First, tell us some details about your service.
+        Form details
       notice:
         Nothing will be put live until you <em>deploy</em> your service -
         which you can do after creating it

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -192,7 +192,7 @@ describe 'visiting /services' do
 
       context 'when I fill in the Service name' do
         before do
-          fill_in('Service name', with: name)
+          fill_in(I18n.t(:name, scope: [:helpers, :label, :service]), with: name)
         end
         context 'with a valid name' do
           let(:name) { 'My new service' }
@@ -209,7 +209,7 @@ describe 'visiting /services' do
 
           context 'and fill in the git repo url' do
             before do
-              fill_in('URL of the service config JSON Git repository', with: url)
+              fill_in(I18n.t(:git_repo_url, scope: [:helpers, :label, :service]), with: url)
             end
             context 'with a valid https git repo url' do
               let(:url) { 'https://git.example.com/repo.git' }
@@ -239,8 +239,8 @@ describe 'visiting /services' do
       let(:service_name) { 'My First Service' }
       before do
         visit '/services/new'
-        fill_in('Service name', with: service_name)
-        fill_in('URL of the service config JSON Git repository', with: 'https://repo.url/repo.git')
+        fill_in(I18n.t(:name, scope: [:helpers, :label, :service]), with: service_name)
+        fill_in(I18n.t(:git_repo_url, scope: [:helpers, :label, :service]), with: 'https://repo.url/repo.git')
         within('#content') do
           click_on(I18n.t(:submit, scope: [:services, :new, :form]))
         end
@@ -281,7 +281,7 @@ describe 'visiting /services' do
 
         describe 'changing the name' do
           before do
-            fill_in('Service name', with: new_name)
+            fill_in(I18n.t(:name, scope: [:helpers, :label, :service]), with: new_name)
             click_button 'Update Service'
           end
           context 'to something valid' do
@@ -300,7 +300,7 @@ describe 'visiting /services' do
             let(:new_name) { '?' }
 
             it 'shows me an error message' do
-              expect(page).to have_content('Service name is too short')
+              expect(page).to have_content('Form name is too short')
             end
 
             it 'keeps me editing my service' do
@@ -313,7 +313,7 @@ describe 'visiting /services' do
           context 'to something valid' do
             let(:slug_name) { 'test-slug' }
             before do
-              fill_in('Service "slug"', with: slug_name)
+              fill_in(I18n.t(:slug, scope: [:helpers, :label, :service]), with: slug_name)
               click_button('Update Service')
             end
 
@@ -344,7 +344,7 @@ describe 'visiting /services' do
           context 'to something invalid' do
             let(:slug_name) { '3' }
             before do
-              fill_in('Service "slug"', with: slug_name)
+              fill_in(I18n.t(:slug, scope: [:helpers, :label, :service]), with: slug_name)
             end
 
             it 'does not update the service slug' do


### PR DESCRIPTION
The following changes have been made:

Heading
Text field changed form changed from "Service name" to "Form name"
Text field changed from "Service slug" to "Form slug"
Text field changed from "URL of the service config JSON Git repository"
to "GitHub repository location"
Changed the instructional text under "GitHub repository location"

**Before:**

<img width="1043" alt="screen shot 2019-01-08 at 10 58 17" src="https://user-images.githubusercontent.com/10685841/50826769-7abdd880-1334-11e9-9f10-b3bdea093f8b.png">

**After:**

<img width="991" alt="screen shot 2019-01-08 at 11 31 24" src="https://user-images.githubusercontent.com/10685841/50828368-223d0a00-1339-11e9-8437-1d0cead316d8.png">


