### PR TITLE
Un-deploy a Service

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -34,6 +34,12 @@ class ServicesController < ApplicationController
   end
 
   def destroy
+    # add job to remove the deployments for each environment(if they exist) of a service
+    # then delete the service
+    ServiceEnvironment.all_slugs.each do |env|
+      deployment = DeploymentService.last_status(service: @service, environment_slug: env)
+      DeployServiceJob.perform_later(service_deployment_id: deployment.id) unless deployment.nil?
+    end
     @service.destroy!
     redirect_to services_path, notice: t(:success, scope: [:services, :destroy], service: @service.name)
   end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -34,11 +34,9 @@ class ServicesController < ApplicationController
   end
 
   def destroy
-    # add job to remove the deployments for each environment(if they exist) of a service
-    # then delete the service
     ServiceEnvironment.all_slugs.each do |env|
       deployment = DeploymentService.last_status(service: @service, environment_slug: env)
-      DeployServiceJob.perform_later(service_deployment_id: deployment.id) unless deployment.nil?
+      UndeployServiceJob.perform_later(service_deployment_id: deployment.id) unless deployment.nil?
     end
     @service.destroy!
     redirect_to services_path, notice: t(:success, scope: [:services, :destroy], service: @service.name)

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -36,8 +36,11 @@ class ServicesController < ApplicationController
   def destroy
     ServiceEnvironment.all_slugs.each do |env|
       deployment = DeploymentService.last_status(service: @service, environment_slug: env)
-      UndeployServiceJob.perform_later(service_deployment_id: deployment.id) unless deployment.nil?
+      unless deployment.nil?
+        UndeployServiceJob.perform_later(env: env.to_s, service_slug: @service.slug)
+      end
     end
+
     @service.destroy!
     redirect_to services_path, notice: t(:success, scope: [:services, :destroy], service: @service.name)
   end

--- a/app/jobs/undeploy_service_job.rb
+++ b/app/jobs/undeploy_service_job.rb
@@ -1,0 +1,52 @@
+class UndeployServiceJob < ApplicationJob
+  queue_as :default
+
+  def perform(service_deployment_id:)
+    @service_deployment_id = service_deployment_id
+    @deployment = ServiceDeployment.find(service_deployment_id)
+
+    log_for_user(:stop_service)
+    DeploymentService.stop_service(
+      environment_slug: @deployment.environment_slug,
+      service: @deployment.service
+    )
+
+    log_for_user(:removed)
+    @deployment.remove!
+
+    log_for_user(:all_done)
+  end
+
+  def on_retryable_exception(error)
+    logger.warn "RETRYABLE EXCEPTION! @deployment #{@deployment.inspect}"
+    @deployment.fail!(retryable: true) if @deployment
+    super
+  end
+
+  def on_non_retryable_exception(error)
+    log_for_user(:failed)
+    @deployment.fail!(retryable: false) if @deployment
+    super
+  end
+
+  def self.log_tag(service_deployment_id)
+    ['ServiceDeploymentId', service_deployment_id].join(':')
+  end
+
+  def log_for_user(message_key, args={})
+    i18n_args = {
+      scope: [:undeploy_service_job],
+      service_deployment_id: @service_deployment_id,
+      job_id: job_id
+    }.merge(args)
+
+    JobLogService.log(
+      message: I18n.t(
+        message_key,
+        i18n_args
+      ),
+      job: self,
+      tag: self.class.log_tag(@service_deployment_id)
+    )
+  end
+end

--- a/app/jobs/undeploy_service_job.rb
+++ b/app/jobs/undeploy_service_job.rb
@@ -20,8 +20,8 @@ class UndeployServiceJob < ApplicationJob
     super
   end
 
-  def self.log_tag
-    ['environment slug', @env].join(':')
+  def self.log_tag(slug, env)
+    "service-slug: #{slug}, environment-slug: #{env}"
   end
 
   def log_for_user(message_key, args={})
@@ -37,7 +37,7 @@ class UndeployServiceJob < ApplicationJob
         i18n_args
       ),
       job: self,
-      tag: self.class.log_tag
+      tag: self.class.log_tag(@slug, @env)
     )
   end
 end

--- a/app/jobs/undeploy_service_job.rb
+++ b/app/jobs/undeploy_service_job.rb
@@ -12,7 +12,7 @@ class UndeployServiceJob < ApplicationJob
     )
 
     log_for_user(:removed)
-    @deployment.remove!
+    @deployment.destroy
 
     log_for_user(:all_done)
   end

--- a/app/models/service_deployment.rb
+++ b/app/models/service_deployment.rb
@@ -56,4 +56,9 @@ class ServiceDeployment < ActiveRecord::Base
     url_link.slice!('.git')
     url_link << '/commit/' << commit_sha
   end
+
+  # Delete the database record
+  def remove!
+    delete
+  end
 end

--- a/app/models/service_deployment.rb
+++ b/app/models/service_deployment.rb
@@ -56,9 +56,4 @@ class ServiceDeployment < ActiveRecord::Base
     url_link.slice!('.git')
     url_link << '/commit/' << commit_sha
   end
-
-  # Delete the database record
-  def remove!
-    delete
-  end
 end

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -97,6 +97,11 @@ class DeploymentService
     )
   end
 
+  def self.stop_service_by_slug(environment_slug:, slug:)
+    adapter = adapter_for(environment_slug)
+    adapter.stop_service_by_slug(slug: slug)
+  end
+
   def self.start_service(environment_slug:, service:, tag:)
     adapter = adapter_for(environment_slug)
     adapter.start_service(

--- a/app/services/generic_kubernetes_platform_adapter.rb
+++ b/app/services/generic_kubernetes_platform_adapter.rb
@@ -76,6 +76,11 @@ class GenericKubernetesPlatformAdapter
     end
   end
 
+  def stop_service_by_slug(slug:)
+    kubernetes_adapter.delete_service(name: slug) if kubernetes_adapter.exists_in_namespace?(name: slug, type: 'service')
+    kubernetes_adapter.delete_deployment(slug) if kubernetes_adapter.exists_in_namespace?(name: slug, type: 'deployment')
+  end
+
   def token_secret_name(service)
     "fb-service-#{service.slug}-token-#{ENV['PLATFORM_ENV']}-#{@environment.slug}"
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,6 +318,8 @@ en:
     update:
       success: Team "%{team}" updated successfully
   undeploy_service_job:
+    all_done: 'ALL DONE'
+    failed: 'JOB FAILED!'
     stop_service: 'Stopped service'
   users:
     edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,6 +317,8 @@ en:
       url: URL
     update:
       success: Team "%{team}" updated successfully
+  undeploy_service_job:
+    stop_service: 'Stopped service'
   users:
     edit:
       heading: 'Profile: %{name}'

--- a/spec/jobs/undeploy_service_job_spec.rb
+++ b/spec/jobs/undeploy_service_job_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+describe UndeployServiceJob do
+  let(:json_sub_dir) { nil }
+  let(:service) { double('service', git_repo_url: 'https://some/repo', slug: 'some-slug') }
+  let(:deployment) do
+    double('deployment',
+           id: 'my-deployment-id',
+           commit_sha: 'tag:5678',
+           json_sub_dir: json_sub_dir,
+           service: service,
+           environment_slug: 'mydev',
+           status: 'completed'
+    )
+  end
+
+  before do
+    allow(JobLogService).to receive(:log)
+    allow(ServiceDeployment).to receive(:find).with('my-deployment-id').and_return(deployment)
+    allow(DeploymentService).to receive(:stop_service).and_return('stop_service-result')
+    allow(deployment).to receive(:remove!)
+  end
+
+  describe 'perform' do
+    let(:perform_and_handle_error) do
+      begin
+        described_class.perform_now(service_deployment_id: deployment.id)
+
+      rescue CmdFailedError => e
+        Rails.logger.info "expected error -- #{e.message}"
+      end
+    end
+
+    context 'when the job does not throw an error' do
+      it 'removes the deployment' do
+        expect(ServiceDeployment).to receive(:find).with('my-deployment-id').and_return(deployment)
+        expect(deployment).to receive(:remove!)
+        subject.perform(service_deployment_id: deployment.id)
+      end
+    end
+
+    # Not sure that I will need this \_@_/
+    context 'when the job throws a retryable error' do
+      before do
+        allow(DeploymentService).to receive(:stop_service).and_raise(Net::OpenTimeout.new("expected exception"))
+        allow(deployment).to receive(:fail!)
+      end
+
+      it 'does not remove the deployment' do
+        expect(deployment).to_not receive(:remove!)
+        perform_and_handle_error
+      end
+
+      it 'logs the error' do
+        expect_any_instance_of(described_class).to receive(:log_error)
+        perform_and_handle_error
+      end
+
+      it 'fail!s the un-deployment passing true for retryable' do
+        expect(deployment).to receive(:fail!).with(retryable: true)
+        perform_and_handle_error
+      end
+    end
+
+    # Not sure that I will need this \_@_/
+    context 'when the job throws a non-retryable error' do
+      before do
+        allow(DeploymentService).to receive(:stop_service).and_raise(CmdFailedError.new("expected exception"))
+        allow(deployment).to receive(:fail!)
+      end
+
+      it 'does not remove! the deployment' do
+        expect(deployment).to_not receive(:remove!)
+        perform_and_handle_error
+      end
+
+      it 'logs the error' do
+        expect_any_instance_of(described_class).to receive(:log_error)
+        perform_and_handle_error
+      end
+
+      it 'fail!s the deployment passing false for retryable' do
+        expect(deployment).to receive(:fail!).with(retryable: false)
+        perform_and_handle_error
+      end
+    end
+  end
+end

--- a/spec/jobs/undeploy_service_job_spec.rb
+++ b/spec/jobs/undeploy_service_job_spec.rb
@@ -30,7 +30,7 @@ describe UndeployServiceJob, type: :job do
     end
   end
 
-  context 'when something unexpected happens' do
+  context 'when the job throws a non-retryable error' do
     let(:perform_and_handle_error) do
       begin
         described_class.perform_now(env: 'mydev', service_slug: 'some-slug')
@@ -40,7 +40,7 @@ describe UndeployServiceJob, type: :job do
       end
     end
 
-    it 'does something I do not understand' do
+    it 'does not attempt to retry the job' do
       allow(DeploymentService).to receive(:stop_service_by_slug).and_raise(CmdFailedError.new("expected exception"))
       perform_enqueued_jobs do
         perform_and_handle_error

--- a/spec/jobs/undeploy_service_job_spec.rb
+++ b/spec/jobs/undeploy_service_job_spec.rb
@@ -18,7 +18,7 @@ describe UndeployServiceJob do
     allow(JobLogService).to receive(:log)
     allow(ServiceDeployment).to receive(:find).with('my-deployment-id').and_return(deployment)
     allow(DeploymentService).to receive(:stop_service).and_return('stop_service-result')
-    allow(deployment).to receive(:remove!)
+    allow(deployment).to receive(:destroy)
   end
 
   describe 'perform' do
@@ -34,12 +34,11 @@ describe UndeployServiceJob do
     context 'when the job does not throw an error' do
       it 'removes the deployment' do
         expect(ServiceDeployment).to receive(:find).with('my-deployment-id').and_return(deployment)
-        expect(deployment).to receive(:remove!)
+        expect(deployment).to receive(:destroy)
         subject.perform(service_deployment_id: deployment.id)
       end
     end
 
-    # Not sure that I will need this \_@_/
     context 'when the job throws a retryable error' do
       before do
         allow(DeploymentService).to receive(:stop_service).and_raise(Net::OpenTimeout.new("expected exception"))
@@ -47,7 +46,7 @@ describe UndeployServiceJob do
       end
 
       it 'does not remove the deployment' do
-        expect(deployment).to_not receive(:remove!)
+        expect(deployment).to_not receive(:destroy)
         perform_and_handle_error
       end
 
@@ -62,7 +61,6 @@ describe UndeployServiceJob do
       end
     end
 
-    # Not sure that I will need this \_@_/
     context 'when the job throws a non-retryable error' do
       before do
         allow(DeploymentService).to receive(:stop_service).and_raise(CmdFailedError.new("expected exception"))
@@ -70,7 +68,7 @@ describe UndeployServiceJob do
       end
 
       it 'does not remove! the deployment' do
-        expect(deployment).to_not receive(:remove!)
+        expect(deployment).to_not receive(:destroy)
         perform_and_handle_error
       end
 


### PR DESCRIPTION
When a user deletes a form (service) any deployments for that service should also be removed from Kubernetes.