### PR TITLE
Fix un-deployment

### DIFF
--- a/app/services/generic_kubernetes_platform_adapter.rb
+++ b/app/services/generic_kubernetes_platform_adapter.rb
@@ -78,7 +78,7 @@ class GenericKubernetesPlatformAdapter
 
   def stop_service_by_slug(slug:)
     kubernetes_adapter.delete_service(name: slug) if kubernetes_adapter.exists_in_namespace?(name: slug, type: 'service')
-    kubernetes_adapter.delete_deployment(slug) if kubernetes_adapter.exists_in_namespace?(name: slug, type: 'deployment')
+    kubernetes_adapter.delete_deployment(name: slug) if kubernetes_adapter.exists_in_namespace?(name: slug, type: 'deployment')
   end
 
   def token_secret_name(service)


### PR DESCRIPTION
From looking at the logs, the method used to delete the Kubernetes deployment was missing the required keyword. Which resulted in the deployment not being deleted.