### PR TITLE
Remove ingress on deleted services

### DIFF
--- a/app/services/generic_kubernetes_platform_adapter.rb
+++ b/app/services/generic_kubernetes_platform_adapter.rb
@@ -79,6 +79,12 @@ class GenericKubernetesPlatformAdapter
   def stop_service_by_slug(slug:)
     kubernetes_adapter.delete_service(name: slug) if kubernetes_adapter.exists_in_namespace?(name: slug, type: 'service')
     kubernetes_adapter.delete_deployment(name: slug) if kubernetes_adapter.exists_in_namespace?(name: slug, type: 'deployment')
+    remove_ingress(slug: slug)
+  end
+
+  def remove_ingress(slug:)
+    ingress_name = "#{slug}-ingress"
+    kubernetes_adapter.delete_ingress(name: ingress_name)
   end
 
   def token_secret_name(service)

--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -107,6 +107,16 @@ class KubernetesAdapter
     )
   end
 
+  def delete_ingress(name:)
+    ShellAdapter.exec(
+      kubectl_binary,
+      'delete',
+      'ingresses.extensions',
+      name,
+      std_args
+    )
+  end
+
   # just writes an updated timestamp annotation -
   # quickest, smoothest and easiest way to refresh a deployment
   # so that it can pick up new configmaps, etc

--- a/spec/services/generic_kubernetes_platform_adapter_spec.rb
+++ b/spec/services/generic_kubernetes_platform_adapter_spec.rb
@@ -106,6 +106,25 @@ describe GenericKubernetesPlatformAdapter do
     end
   end
 
+  describe '.remove_ingress' do
+    let(:service) { Service.new(name: 'my service', slug: 'my-service') }
+    let(:result) { 'oh yes' }
+    before do
+      allow(subject.kubernetes_adapter).to receive(:delete_ingress).and_return(result)
+    end
+
+    it 'asks the kubernetes_adapter to delete ingress with the a specific name' do
+      expect(subject.kubernetes_adapter).to receive(:delete_ingress).with(
+        name: "#{service.slug}-ingress"
+      ).and_return(result)
+      subject.remove_ingress(slug: service.slug)
+    end
+
+    it 'returns the result of the kubernetes_adapter call' do
+      expect(subject.remove_ingress(slug: service.slug)).to eq(result)
+    end
+  end
+
   describe '.delete_deployment' do
     let(:service) { Service.new(name: 'my service', slug: 'my-service') }
     let(:result) { 'oh yes' }


### PR DESCRIPTION
Delete the ingress associated to a service (form), when that service has been deleted. Tested this on the test environment and it works.