### PR TITLE
create network policy for form

### DIFF
--- a/app/jobs/deploy_service_job.rb
+++ b/app/jobs/deploy_service_job.rb
@@ -51,6 +51,12 @@ class DeployServiceJob < ApplicationJob
       service: @deployment.service
     )
 
+    log_for_user(:creating_network_policy)
+    DeploymentService.create_network_policy(
+      config_dir: config_dir,
+      environment_slug: @deployment.environment_slug
+    )
+
     log_for_user(:restarting)
     DeploymentService.restart_service(
       environment_slug: @deployment.environment_slug,

--- a/app/services/cloud_platform_adapter.rb
+++ b/app/services/cloud_platform_adapter.rb
@@ -75,6 +75,21 @@ class CloudPlatformAdapter < GenericKubernetesPlatformAdapter
     end
   end
 
+  def create_network_policy(config_dir:, environment_slug:)
+    @platform_environment = PLATFORM_ENV
+    @deployment_environment = environment_slug
+
+    template = File.open(Rails.root.join('config', 'k8s_templates', 'network_policy.yaml.erb'), 'r').read
+    erb = ERB.new(template)
+    output = erb.result(binding)
+    path = "#{config_dir}/network_policy.yaml"
+
+    File.open(path, 'w') do |f|
+      f.write(output)
+    end
+
+    kubernetes_adapter.apply_file(file: path)
+  end
 
   def create_ingress_rule(service:, config_dir:)
     url = url_for(service: service)

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -138,6 +138,12 @@ class DeploymentService
                             status: 'completed').order(completed_at: :desc).first
   end
 
+  def self.create_network_policy(config_dir:, environment_slug:)
+    adapter = adapter_for(environment_slug)
+    adapter.create_network_policy(config_dir: config_dir,
+                                  environment_slug: environment_slug)
+  end
+
   private
 
   def self.empty_deployment(service:, environment_slug:)

--- a/config/k8s_templates/network_policy.yaml.erb
+++ b/config/k8s_templates/network_policy.yaml.erb
@@ -1,0 +1,24 @@
+# We must also allow the submitter to access any pods in the services NS
+# so that it can retrieve the mail body parts & PDFs
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-submitter-to-access-services
+  namespace: formbuilder-services-<%= @platform_environment %>-<%= @deployment_environment %>
+spec:
+  # empty podSelector means 'all pods'
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: formbuilder-platform-<%= @platform_environment %>-<%= @deployment_environment %>
+      # This is a kubernetes 1.11 feature, the live cluster is still on 1.10
+      # podSelector:
+      #   matchLabels:
+      #     app: fb-submitter-workers-test-dev
+    ports:
+    - protocol: TCP
+      port: 3000

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
     creating_service_token_secret: 'Creating secret for service token'
     deploying_service: 'Deploying service'
     exposing: 'Allowing inbound traffic'
+    creating_network_policy: 'Creating network policy'
     failed: 'JOB FAILED!'
     reading_commit: 'Reading commit SHA'
     restarting: 'Restarting service'

--- a/spec/jobs/deploy_service_job_spec.rb
+++ b/spec/jobs/deploy_service_job_spec.rb
@@ -22,6 +22,7 @@ describe DeployServiceJob do
     allow(VersionControlService).to receive(:checkout).and_return('some-sha')
     allow(DeploymentService).to receive(:setup_service).and_return('setup_service-result')
     allow(DeploymentService).to receive(:expose).and_return('expose-result')
+    allow(DeploymentService).to receive(:create_network_policy)
     allow(DeploymentService).to receive(:configure_env_vars).and_return('configure_env_vars-result')
     allow(DeploymentService).to receive(:restart_service).and_return('restart_service-result')
     allow(DeploymentService).to receive(:create_service_token_secret).and_return('create_service_token_secret-result')
@@ -39,6 +40,11 @@ describe DeployServiceJob do
       rescue CmdFailedError => e
         Rails.logger.info "expected error -- #{e.message}"
       end
+    end
+
+    it 'calls create_network_policy' do
+      expect(DeploymentService).to receive(:create_network_policy)
+      perform
     end
 
     it 'loads the deployment' do

--- a/spec/services/cloud_platform_adapter_spec.rb
+++ b/spec/services/cloud_platform_adapter_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe CloudPlatformAdapter do
+  describe '#create_network_policy' do
+    let(:mock_adapter) { double('adapter').as_null_object }
+
+    before :each do
+      FileUtils.rm_f('/tmp/network_policy.yaml')
+
+      stub_const('PLATFORM_ENV', 'test')
+    end
+
+    subject do
+      described_class.new(environment: nil, kubernetes_adapter: mock_adapter)
+    end
+
+    it 'generates network_policy.yaml' do
+      subject.create_network_policy(config_dir: '/tmp/',
+                                    environment_slug: 'dev')
+
+      expect(File.exist?('/tmp/network_policy.yaml')).to be_truthy
+    end
+
+    it 'generates network_policy.yaml with correct contents' do
+      subject.create_network_policy(config_dir: '/tmp',
+                                    environment_slug: 'dev')
+
+      contents = File.open('/tmp/network_policy.yaml').read
+
+      expect(contents).to include('networking.k8s.io/v1')
+      expect(contents).to include('namespace: formbuilder-services-test-dev')
+      expect(contents).to include('name: formbuilder-platform-test-dev')
+    end
+
+    it 'applies network_policy.yaml' do
+      expect(mock_adapter).to receive(:apply_file).with(file: '/tmp/network_policy.yaml').and_return(true)
+
+      subject.create_network_policy(config_dir: '/tmp',
+                                    environment_slug: 'dev')
+    end
+  end
+end

--- a/spec/services/deployment_service_spec.rb
+++ b/spec/services/deployment_service_spec.rb
@@ -5,7 +5,6 @@ describe DeploymentService do
   let(:deployment_dev){ double(ServiceDeployment) }
   let(:deployment_staging){ double(ServiceDeployment) }
 
-
   describe '.service_status' do
     describe 'given multiple environment_slugs' do
       let(:slugs) { [:dev, :staging] }
@@ -284,6 +283,30 @@ describe DeploymentService do
     it 'asks the adapter to expose passing on all args except environment_slug' do
       expect(mock_adapter).to receive(:expose).with(args.except(:environment_slug)).and_return(mock_adapter)
       described_class.expose(args)
+    end
+  end
+
+  describe '#create_network_policy' do
+    let(:mock_adapter) { double('adapter', create_network_policy: true) }
+    let(:args) do
+      {
+        config_dir: 'config_dir',
+        environment_slug: 'env_slug'
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:adapter_for).and_return(mock_adapter)
+    end
+
+    it 'gets the adapter for the given environment_slug' do
+      expect(described_class).to receive(:adapter_for).with('env_slug').and_return(mock_adapter)
+      described_class.create_network_policy(args)
+    end
+
+    it 'asks the adapter to expose passing on all args except environment_slug' do
+      expect(mock_adapter).to receive(:create_network_policy).with(args).and_return(mock_adapter)
+      described_class.create_network_policy(args)
     end
   end
 


### PR DESCRIPTION
this allows ingress from platform namespace to the service namespace
this is being moved from the submitter deployment to here
so the service/form is responsible for its own network policies