### PR TITLE
Rolling deployments

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -28,10 +28,6 @@ To use the following scripts, first run `npm install`
 
   Script to initialise/update Kubernetes deployments for a platform environment
 
-- `scripts/restart_platform_pods.sh`
-
-  Script to explicitly restart pods in a platform environment
-
 All these scripts print out their usage instructions by being run with the `-h` flag
 
 ## Configuration files
@@ -100,7 +96,7 @@ See the `Makefile` for more info.
     - `secret_key_base`
       Rails secret
 
-- Run the `scripts/deploy_platform.sh` script which 
+- Run the `scripts/deploy_platform.sh` script which
 
   - generates the necessary kubernetees configuration to deploy the application
   - applies the configuration
@@ -111,44 +107,10 @@ The generated config for each platform/deployment environment combination is wri
 
 ### 4. Running the Rails setup scripts
 
-The first time the infrastructure is created, the Rails setup scripts need to be run. This needs to be run on one of the pods that has been created 
+The first time the infrastructure is created, the Rails setup scripts need to be run. This needs to be run on one of the pods that has been created
 
 ```bash
 kubectl exec -ti $PODNAME --namespace=formbuilder-platform-$PLATFORM_ENV-$DEPLOYMENT_ENV  -- bundle exec rails db:setup db:migrate
 ```
 
 **TODO: Make rails setup run automatically without failure preventing further scripts running**
-
-### 5. Deploying an updated docker image to existing infrastructure
-
-Deleting the currently running pods will trigger the kubernetes Deployment to recreate pods until it has its specified minimum number running - as the Deployment has `imagePullPolicy: Always`, it will pull the latest docker image from Cloud Platform's ECR.
-
-`scripts/restart_platform_pods.sh` is a convenience script that deletes all pods in all deployment environments accross a platform environment.
-
-Running
-
-```bash
-scripts/restart_platform_pods.sh -p $PLATFORM_ENV
-```
-
-is equivalent to
-
-```bash
-kubectl delete pods -l appGroup=fb-publisher --namespace=formbuilder-platform-$PLATFORM_ENV-dev &\
-kubectl delete pods -l appGroup=fb-publisher --namespace=formbuilder-platform-$PLATFORM_ENV-staging &\
-kubectl delete pods -l appGroup=fb-publisher --namespace=formbuilder-platform-$PLATFORM_ENV-production &
-```
-
-To restart just the `api` pods in a specific deployment environment
-
-```bash
-kubectl delete pods -l app=fb-publisher-api-$PLATFORM_ENV-$DEPLOYMENT_ENV  --namespace=formbuilder-platform-$PLATFORM_ENV-$DEPLOYMENT_ENV &
-```
-
-To restart just the `worker` pods in a specific deployment environment
-
-```bash
-kubectl delete pods -l app=fb-publisher-workers-$PLATFORM_ENV-$DEPLOYMENT_ENV --namespace=formbuilder-platform-$PLATFORM_ENV-$DEPLOYMENT_ENV
-```
-
-

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,12 @@ target:
 ifeq ($(TARGETDEFINED), "true")
 	$(eval export env_stub=${TARGET})
 	@true
-else 
+else
 	$(info Must set TARGET)
 	@false
 endif
 
 init:
-	$(eval export ECR_REPO_NAME_SUFFIXES=base web worker)
 	$(eval export ECR_REPO_URL_ROOT=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder)
 
 # install aws cli w/o sudo
@@ -39,11 +38,8 @@ install_build_dependencies: init
 	pip install --user awscli
 	$(eval export PATH=${PATH}:${HOME}/.local/bin/)
 
-
 # Needs ECR_REPO_NAME & ECR_REPO_URL env vars
 build_and_push: install_build_dependencies
-	TAG="latest-${env_stub}" REPO_SCOPE=${ECR_REPO_URL_ROOT} ./scripts/build_and_push_all.sh
-
-
+	TAG="latest-${env_stub}" CIRCLE_SHA1=${CIRCLE_SHA1} REPO_SCOPE=${ECR_REPO_URL_ROOT} ./scripts/build_and_push_all.sh
 
 .PHONY := init push build login

--- a/deploy/fb-publisher-chart/templates/deployment.yaml
+++ b/deploy/fb-publisher-chart/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         runAsUser: 1001
       containers:
       - name: "fb-publisher-web-{{ .Values.environmentName }}"
-        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-publisher-web:latest-{{ .Values.environmentName }}"
+        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-publisher-web:{{ .Values.circleSha1 }}"
         imagePullPolicy: Always
         ports:
           - containerPort: 3000
@@ -102,7 +102,7 @@ spec:
       serviceAccountName: "formbuilder-publisher-workers-{{ .Values.environmentName }}"
       containers:
       - name: "fb-publisher-worker"
-        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-publisher-worker:latest-{{ .Values.environmentName }}"
+        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-publisher-worker:{{ .Values.circleSha1 }}"
         imagePullPolicy: Always
         # command:
         #   - "cd /var/www/fb-publisher && bundle exec rake resque:work"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/ministryofjustice/fb-publisher#readme",
   "dependencies": {},
   "devDependencies": {
-    "@ministryofjustice/fb-deploy-utils": "^1.0.6"
+    "@ministryofjustice/fb-deploy-utils": "^1.0.10"
   }
 }

--- a/scripts/build_and_push_all.sh
+++ b/scripts/build_and_push_all.sh
@@ -25,9 +25,10 @@ for TYPE in base web worker
 do
   REPO_NAME=${REPO_SCOPE}/fb-publisher-${TYPE}
   echo "Building ${REPO_NAME}"
-  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-publisher-base:${TAG} .
+  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} -t ${REPO_NAME}:${CIRCLE_SHA1} --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-publisher-base:${TAG} .
 
   login_to_ecr_with_creds_for ${TYPE}
   echo "Pushing ${REPO_NAME}"
   docker push ${REPO_NAME}:${TAG}
+  docker push ${REPO_NAME}:${CIRCLE_SHA1}
 done

--- a/scripts/circleci_deploy.sh
+++ b/scripts/circleci_deploy.sh
@@ -19,7 +19,4 @@ echo "kubectl use circleci context"
 kubectl config use-context "circleci_${environment_name}"
 
 echo "apply kubernetes changes to ${environment_name}"
-./scripts/deploy_platform.sh -p $environment_name
-
-echo "delete pods in ${environment_name}"
-./scripts/restart_platform_pods.sh -p $environment_name -c "circleci_${environment_name}"
+./scripts/deploy_platform.sh -p $environment_name -s $CIRCLE_SHA1

--- a/scripts/restart_platform_pods.sh
+++ b/scripts/restart_platform_pods.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-FB_APPLICATION='fb-publisher' FB_NAMESPACE=publisher FB_DEPLOYMENT_ENV=none node_modules/\@ministryofjustice/fb-deploy-utils/bin/restart_platform_pods.sh $@


### PR DESCRIPTION
Instead of manually deleting pods (resulting in downtime), use kubernetes
built-in rolling deployments.  This requires a dynamic tag on the container
image that can be referred to by the Helm deployment.yaml file.

By simply using a tag like latest, that never changes, kubernetes won't pick up
that anything has changed and not deploy.