### PR TITLE
inject sentry api keys into runner instances

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -385,6 +385,8 @@ class KubernetesAdapter
                 value: #{ENV['PLATFORM_ENV']}
               - name: DEPLOYMENT_ENV
                 value: #{@environment.slug}
+              - name: SENTRY_DSN
+                value: #{ENV['RUNNER_SENTRY_DSN']}
             image: #{image}
             imagePullPolicy: Always
             ports:

--- a/deploy/fb-publisher-chart/templates/deployment.yaml
+++ b/deploy/fb-publisher-chart/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
               secretKeyRef:
                 name: fb-publisher-app-secrets-{{ .Values.environmentName }}
                 key: sentry_dsn
+          - name: RUNNER_SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: fb-publisher-app-secrets-{{ .Values.environmentName }}
+                key: runner_sentry_dsn
 ---
 # workers
 apiVersion: extensions/v1beta1
@@ -155,3 +160,8 @@ spec:
               secretKeyRef:
                 name: fb-publisher-app-secrets-{{ .Values.environmentName }}
                 key: sentry_dsn
+          - name: RUNNER_SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: fb-publisher-app-secrets-{{ .Values.environmentName }}
+                key: runner_sentry_dsn

--- a/deploy/fb-publisher-chart/templates/secrets.yaml
+++ b/deploy/fb-publisher-chart/templates/secrets.yaml
@@ -8,3 +8,4 @@ data:
   auth0_client_secret: {{ .Values.auth0_client_secret }}
   secret_key_base: {{ .Values.secret_key_base }}
   sentry_dsn: {{ .Values.sentry_dsn }}
+  runner_sentry_dsn: {{ .Values.runner_sentry_dsn }}


### PR DESCRIPTION
- this means all runner instances created will have `SENTRY_DSN` injected. runner instances can then use this send any exceptions to sentry
- there is therefore no (further) need for users to set these values within publisher via config params