### PR TITLE
Rolling restart user forms

### DIFF
--- a/app/services/cloud_platform_adapter.rb
+++ b/app/services/cloud_platform_adapter.rb
@@ -101,6 +101,10 @@ class CloudPlatformAdapter < GenericKubernetesPlatformAdapter
     )
   end
 
+  def patch_deployment(name:)
+    kubernetes_adapter.patch_deployment(name: name)
+  end
+
   ##############################################################
   # Everything below here is the same for the minikube adapter
   # TODO: refactor for DRY-ness!

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -112,12 +112,7 @@ class DeploymentService
 
   def self.restart_service(service:, environment_slug:)
     adapter = adapter_for(environment_slug)
-    # The deployment will detect that the pods have been
-    # deleted, and instantly begin creating new ones
-    # that will pick up any new config maps or json
-    adapter.delete_pods(
-      service: service
-    )
+    adapter.patch_deployment(name: service.slug)
   end
 
   def self.url_for(environment_slug:, service:)

--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -312,7 +312,7 @@ class KubernetesAdapter
   end
 
   def timestamp_annotation
-    "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"updated_at\":\"`date +'%s'`\"}}}}}"
+    "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"updated_at\":\"#{Time.now.to_i}\"}}}}}"
   end
 
   def secret(name:, key_ref:, value:)
@@ -401,7 +401,7 @@ class KubernetesAdapter
   end
 
   def config_map(vars: {}, name:)
-    # Mapping of vars ensures that all values are quoted to ensure that 
+    # Mapping of vars ensures that all values are quoted to ensure that
     # characters such as { do not cause the resulting YAML to be invalid
     # NB. if this method is used to generate config maps that contain numbers
     # this will need updating accordingly

--- a/spec/services/cloud_platform_adapter_spec.rb
+++ b/spec/services/cloud_platform_adapter_spec.rb
@@ -21,6 +21,12 @@ describe CloudPlatformAdapter do
       expect(File.exist?('/tmp/network_policy.yaml')).to be_truthy
     end
 
+    it 'forces a rolling deployment by patching the existing deployment' do
+      subject.patch_deployment(name: 'some-deployment-name')
+
+      expect(mock_adapter).to have_received(:patch_deployment).with(name: 'some-deployment-name')
+    end
+
     it 'generates network_policy.yaml with correct contents' do
       subject.create_network_policy(config_dir: '/tmp',
                                     environment_slug: 'dev')

--- a/spec/services/deployment_service_spec.rb
+++ b/spec/services/deployment_service_spec.rb
@@ -335,25 +335,26 @@ describe DeploymentService do
   end
 
   describe '.restart_service' do
-    let(:mock_adapter) { double('adapter', delete_pods: true) }
+    let(:mock_adapter) { double('KubernetesAdapter', patch_deployment: true) }
     let(:args) {
       {
         environment_slug: 'env_slug',
-        service: 'service'
+        service: double(slug: 'some-service')
       }
     }
+
     before do
       allow(described_class).to receive(:adapter_for).and_return(mock_adapter)
     end
 
     it 'gets the adapter for the given environment_slug' do
-      expect(described_class).to receive(:adapter_for).with('env_slug').and_return(mock_adapter)
       described_class.restart_service(args)
+      expect(described_class).to have_received(:adapter_for).with('env_slug')
     end
 
     it 'asks the adapter to delete_pods passing on all args except environment_slug' do
-      expect(mock_adapter).to receive(:delete_pods).with(args.except(:environment_slug)).and_return(mock_adapter)
       described_class.restart_service(args)
+      expect(mock_adapter).to have_received(:patch_deployment).with(name: 'some-service')
     end
   end
 


### PR DESCRIPTION
Rolling restarts on user forms

We used to delete the pods for a newly deployed form to re-deploy them.
This resulted in downtime. By patching a deployment, we can force a new
Rolling deploy.  Use existing (unused) patch_deployment method to
achieve this.