### PR TITLE
generate k8s services and add service monitors

### DIFF
--- a/app/jobs/deploy_service_job.rb
+++ b/app/jobs/deploy_service_job.rb
@@ -58,6 +58,13 @@ class DeployServiceJob < ApplicationJob
       environment_slug: @deployment.environment_slug
     )
 
+    log_for_user(:creating_service_monitor)
+    DeploymentService.create_service_monitor(
+      service: @deployment.service,
+      config_dir: config_dir,
+      environment_slug: @deployment.environment_slug
+    )
+
     log_for_user(:restarting)
     DeploymentService.restart_service(
       environment_slug: @deployment.environment_slug,

--- a/app/services/cloud_platform_adapter.rb
+++ b/app/services/cloud_platform_adapter.rb
@@ -48,6 +48,9 @@ class CloudPlatformAdapter < GenericKubernetesPlatformAdapter
       config_map_name: kubernetes_adapter.config_map_name(service: service),
       service: service
     )
+
+    kubernetes_adapter.create_service(service: service,
+                                      config_dir: config_dir)
   end
 
   def expose(
@@ -91,6 +94,22 @@ class CloudPlatformAdapter < GenericKubernetesPlatformAdapter
     kubernetes_adapter.apply_file(file: path)
   end
 
+  def create_service_monitor(service:, config_dir:, environment_slug:)
+    @platform_environment = PLATFORM_ENV
+    @deployment_environment = environment_slug
+
+    template = File.open(Rails.root.join('config', 'k8s_templates', 'service_monitor.yaml.erb'), 'r').read
+    erb = ERB.new(template)
+    output = erb.result(binding)
+    path = "#{config_dir}/service_monitor.yaml"
+
+    File.open(path, 'w') do |f|
+      f.write(output)
+    end
+
+    kubernetes_adapter.apply_file(file: path)
+  end
+
   def create_ingress_rule(service:, config_dir:)
     url = url_for(service: service)
 
@@ -111,7 +130,4 @@ class CloudPlatformAdapter < GenericKubernetesPlatformAdapter
       service: service
     )
   end
-
-
-
 end

--- a/app/services/deployment_service.rb
+++ b/app/services/deployment_service.rb
@@ -144,6 +144,13 @@ class DeploymentService
                                   environment_slug: environment_slug)
   end
 
+  def self.create_service_monitor(service:, config_dir:, environment_slug:)
+    adapter = adapter_for(environment_slug)
+    adapter.create_service_monitor(service: service,
+                                   config_dir: config_dir,
+                                   environment_slug: environment_slug)
+  end
+
   private
 
   def self.empty_deployment(service:, environment_slug:)

--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -197,6 +197,19 @@ class KubernetesAdapter
     apply_file(file: file)
   end
 
+  def create_service(config_dir:, service:)
+    template = File.open(Rails.root.join('config', 'k8s_templates', 'service.yaml.erb'), 'r').read
+    erb = ERB.new(template)
+    output = erb.result(binding)
+    path = "#{config_dir}/service.yml"
+
+    File.open(path, 'w') do |f|
+      f.write(output)
+    end
+
+    apply_file(file: path)
+  end
+
   def write_config_file(file:, content:)
     FileUtils.mkdir_p(File.dirname(file))
     File.open(file, 'w+') do |f|

--- a/config/k8s_templates/service.yaml.erb
+++ b/config/k8s_templates/service.yaml.erb
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: <%= service.slug %>
+  name: <%= service.slug %>
+  namespace: <%= @environment.namespace %>
+spec:
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    run: <%= service.slug %>

--- a/config/k8s_templates/service_monitor.yaml.erb
+++ b/config/k8s_templates/service_monitor.yaml.erb
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: formbuilder-form-<%= service.slug %>-service-monitor-test-dev
+  namespace: formbuilder-services-<%= @platform_environment %>-<%= @deployment_environment %>
+spec:
+  selector:
+    matchLabels:
+      run: <%= service.slug %>
+  endpoints:
+  - port: http
+    interval: 15s
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: formbuilder-form-<%= service.slug %>-service-monitor-ingress-<%= @platform_environment %>-<%= @deployment_environment %>
+  namespace: formbuilder-services-<%= @platform_environment %>-<%= @deployment_environment %>
+spec:
+  podSelector:
+    matchLabels:
+      run: <%= service.slug %>
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,7 @@ en:
     deploying_service: 'Deploying service'
     exposing: 'Allowing inbound traffic'
     creating_network_policy: 'Creating network policy'
+    creating_service_monitor: 'Creating service monitor'
     failed: 'JOB FAILED!'
     reading_commit: 'Reading commit SHA'
     restarting: 'Restarting service'

--- a/spec/jobs/deploy_service_job_spec.rb
+++ b/spec/jobs/deploy_service_job_spec.rb
@@ -23,6 +23,7 @@ describe DeployServiceJob do
     allow(DeploymentService).to receive(:setup_service).and_return('setup_service-result')
     allow(DeploymentService).to receive(:expose).and_return('expose-result')
     allow(DeploymentService).to receive(:create_network_policy)
+    allow(DeploymentService).to receive(:create_service_monitor)
     allow(DeploymentService).to receive(:configure_env_vars).and_return('configure_env_vars-result')
     allow(DeploymentService).to receive(:restart_service).and_return('restart_service-result')
     allow(DeploymentService).to receive(:create_service_token_secret).and_return('create_service_token_secret-result')
@@ -44,6 +45,11 @@ describe DeployServiceJob do
 
     it 'calls create_network_policy' do
       expect(DeploymentService).to receive(:create_network_policy)
+      perform
+    end
+
+    it 'calls create_service_monitor' do
+      expect(DeploymentService).to receive(:create_service_monitor)
       perform
     end
 

--- a/spec/services/cloud_platform_adapter_spec.rb
+++ b/spec/services/cloud_platform_adapter_spec.rb
@@ -1,6 +1,32 @@
 require 'rails_helper'
 
 describe CloudPlatformAdapter do
+  describe '#setup_service' do
+    let(:mock_adapter) { double('adapter').as_null_object }
+    let(:service) { double('service').as_null_object }
+    let(:config_dir) { '/tmp' }
+
+    before :each do
+      FileUtils.rm_f('/tmp/network_policy.yaml')
+
+      stub_const('PLATFORM_ENV', 'test')
+    end
+
+    subject do
+      described_class.new(environment: nil, kubernetes_adapter: mock_adapter)
+    end
+
+    it 'calls create_service' do
+      expect(mock_adapter).to receive(:create_service).with(service: service,
+                                                            config_dir: config_dir)
+
+      subject.setup_service(service: service,
+                            deployment: double('deployment').as_null_object,
+                            config_dir: config_dir,
+                            image: double('image'))
+    end
+  end
+
   describe '#create_network_policy' do
     let(:mock_adapter) { double('adapter').as_null_object }
 
@@ -37,6 +63,62 @@ describe CloudPlatformAdapter do
 
       subject.create_network_policy(config_dir: '/tmp',
                                     environment_slug: 'dev')
+    end
+  end
+
+  describe '#create_service_monitor' do
+    let(:mock_adapter) { double('adapter').as_null_object }
+    let(:path) { '/tmp/service_monitor.yaml' }
+    let(:service) { Service.new(slug: 'ioj') }
+
+    before :each do
+      FileUtils.rm_f(path)
+
+      stub_const('PLATFORM_ENV', 'test')
+    end
+
+    subject do
+      described_class.new(environment: nil, kubernetes_adapter: mock_adapter)
+    end
+
+    it 'generates service_monitor.yaml' do
+      subject.create_service_monitor(service: service,
+                                     config_dir: '/tmp/',
+                                     environment_slug: 'dev')
+
+      expect(File.exist?(path)).to be_truthy
+    end
+
+    it 'generates service_monitor.yaml with correct contents' do
+      subject.create_service_monitor(service: service,
+                                     config_dir: '/tmp',
+                                     environment_slug: 'dev')
+
+      hash = YAML.load_stream(File.open(path))
+
+      expect(hash.dig(0, 'apiVersion')).to eql('monitoring.coreos.com/v1')
+      expect(hash.dig(0, 'kind')).to eql('ServiceMonitor')
+
+      expect(hash.dig(0, 'metadata', 'name')).to eql('formbuilder-form-ioj-service-monitor-test-dev')
+      expect(hash.dig(0, 'metadata', 'namespace')).to eql('formbuilder-services-test-dev')
+
+      expect(hash.dig(0, 'spec', 'selector', 'matchLabels', 'run')).to eql('ioj')
+
+      expect(hash.dig(1, 'apiVersion')).to eql('networking.k8s.io/v1')
+      expect(hash.dig(1, 'kind')).to eql('NetworkPolicy')
+
+      expect(hash.dig(1, 'metadata', 'name')).to eql('formbuilder-form-ioj-service-monitor-ingress-test-dev')
+      expect(hash.dig(1, 'metadata', 'namespace')).to eql('formbuilder-services-test-dev')
+
+      expect(hash.dig(1, 'spec', 'podSelector', 'matchLabels', 'run')).to eql('ioj')
+    end
+
+    it 'applies service_monitor.yaml' do
+      expect(mock_adapter).to receive(:apply_file).with(file: '/tmp/service_monitor.yaml').and_return(true)
+
+      subject.create_service_monitor(service: service,
+                                     config_dir: '/tmp',
+                                     environment_slug: 'dev')
     end
   end
 end

--- a/spec/services/deployment_service_spec.rb
+++ b/spec/services/deployment_service_spec.rb
@@ -304,9 +304,34 @@ describe DeploymentService do
       described_class.create_network_policy(args)
     end
 
-    it 'asks the adapter to expose passing on all args except environment_slug' do
+    it 'asks the adapter to expose passing on all args' do
       expect(mock_adapter).to receive(:create_network_policy).with(args).and_return(mock_adapter)
       described_class.create_network_policy(args)
+    end
+  end
+
+  describe '#create_service_monitor' do
+    let(:mock_adapter) { double('adapter', create_service_monitor: true) }
+    let(:args) do
+      {
+        service: double(service, slug: 'service-slug'),
+        config_dir: 'config_dir',
+        environment_slug: 'env_slug'
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:adapter_for).and_return(mock_adapter)
+    end
+
+    it 'gets the adapter for the given environment_slug' do
+      expect(described_class).to receive(:adapter_for).with('env_slug').and_return(mock_adapter)
+      described_class.create_service_monitor(args)
+    end
+
+    it 'asks the adapter to expose passing on all args' do
+      expect(mock_adapter).to receive(:create_service_monitor).with(args).and_return(mock_adapter)
+      described_class.create_service_monitor(args)
     end
   end
 


### PR DESCRIPTION
Previously we were not explicity generating kubernetes Services for each form
This is now done exposing a named http port
This is needed for the newly added ServiceMonitor
ServiceMonitor exposes custom metrics for prometheus