### PR TITLE
Ensure user forms are ready to serve traffic

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -404,6 +404,13 @@ class KubernetesAdapter
             imagePullPolicy: Always
             ports:
             - containerPort: #{container_port}
+            readinessProbe:
+              httpGet:
+                path: /ping.json
+                port: #{container_port}
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              successThreshold: 1
             volumeMounts:
             - name: json-repo
               mountPath: /usr/app


### PR DESCRIPTION
Use the ping.json endpoint to ensure that the node application is ready
before sending traffic to it.