### PR TITLE
adding custom-http-errors annotation in the ingress rule

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -448,6 +448,7 @@ class KubernetesAdapter
       annotations:
         kubernetes.io/ingress.class: "nginx"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/custom-http-errors: "502"
     spec:
       tls:
         - hosts:


### PR DESCRIPTION
adding this annotation should allow ingress to serve a custom 502 error page, if the node application suddenly stop or fails to start and the pod is still alive