### PR TITLE
Serve own 4xx 5xx pages

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -454,7 +454,7 @@ class KubernetesAdapter
       annotations:
         kubernetes.io/ingress.class: "nginx"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
-        nginx.ingress.kubernetes.io/custom-http-errors: "502"
+        nginx.ingress.kubernetes.io/custom-http-errors: "400, 403, 404"
     spec:
       tls:
         - hosts:

--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -454,7 +454,7 @@ class KubernetesAdapter
       annotations:
         kubernetes.io/ingress.class: "nginx"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
-        nginx.ingress.kubernetes.io/custom-http-errors: "400, 403, 404"
+        nginx.ingress.kubernetes.io/custom-http-errors: "400, 401, 403, 404, 500, 503"
     spec:
       tls:
         - hosts:


### PR DESCRIPTION
Overrides the generic error pages set in https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/327/files for the errors that can be served by the app. Eg: not "app down" errors.