### PR TITLE
add quotes around SERVICE_SHA

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -404,7 +404,7 @@ class KubernetesAdapter
               - name: SENTRY_DSN
                 value: #{ENV['RUNNER_SENTRY_DSN']}
               - name: SERVICE_SHA
-                value: #{commit_ref}
+                value: "#{commit_ref}"
             image: #{image}
             imagePullPolicy: Always
             ports:

--- a/spec/services/kubernetes_adapter_spec.rb
+++ b/spec/services/kubernetes_adapter_spec.rb
@@ -89,6 +89,14 @@ describe KubernetesAdapter do
         expect(value).to eql('service_sha_goes_here')
       end
 
+      it 'quotes SERVICE_SHA so it always treated as string' do
+        create_deployment
+
+        string = File.read(config_dir.join(filename))
+
+        expect(string).to match(/name: SERVICE_SHA\n\s*value: \"service_sha_goes_here\"/)
+      end
+
       it 'sets default resources' do
         create_deployment
 


### PR DESCRIPTION
otherwise if short SHA only contains numbers kubernetes treats value
as an integer and not a string