### PR TITLE
Dynamic bundle flags based on environment

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p $RAILS_ROOT
 WORKDIR $RAILS_ROOT
 
 COPY Gemfile.lock Gemfile ./
-RUN bundle install --jobs 4 --retry 5 --deployment --without test development
+RUN bundle install --jobs 4 --retry 5 ${BUNDLE_FLAGS}
 
 COPY . .
 

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -9,5 +9,5 @@ for TYPE in web worker
 do
   REPO_NAME=${REPO_SCOPE}/fb-publisher-${TYPE}
   echo "Building ${REPO_NAME}"
-  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} --build-arg BUNDLE_FLAGS='--without test development' --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-publisher-base:${TAG} .
+  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} --build-arg BUNDLE_FLAGS='--deployment --without test development' --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-publisher-base:${TAG} .
 done

--- a/scripts/build_and_push_all.sh
+++ b/scripts/build_and_push_all.sh
@@ -25,7 +25,7 @@ for TYPE in web worker
 do
   REPO_NAME=${REPO_SCOPE}/fb-publisher-${TYPE}
   echo "Building ${REPO_NAME}"
-  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} -t ${REPO_NAME}:${CIRCLE_SHA1} --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-publisher-base:${TAG} --build-arg BUNDLE_FLAGS="--without test development" .
+  docker build -f docker/${TYPE}/Dockerfile -t ${REPO_NAME}:${TAG} -t ${REPO_NAME}:${CIRCLE_SHA1} --build-arg BASE_IMAGE=${REPO_SCOPE}/fb-publisher-base:${TAG} --build-arg BUNDLE_FLAGS="--deployment --without test development" .
 
   login_to_ecr_with_creds_for ${TYPE}
   echo "Pushing ${REPO_NAME}"


### PR DESCRIPTION
To only install the correct dependencies per environment, we need to set a flag
which differs from CI deployments to local dev installs