### PR TITLE
Bundle flags arg

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,16 @@ services:
       - app
     ports:
       - 8000:80
+    links:
+      - publisher-redis
+    environment:
+      REDISCLOUD_URL: "publisher-redis"
+      QUEUE: "*"
+
+  publisher-redis:
+    image: 'bitnami/redis:5.0'
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+    ports:
+      - '6379:6379'

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -11,7 +11,8 @@ WORKDIR $RAILS_ROOT
 COPY Gemfile.lock Gemfile ./
 ENV BUNDLER_VERSION 2.0.2
 RUN gem install bundler
-RUN bundle install --jobs 4 --retry 5 --deployment --without test development
+ARG BUNDLE_FLAGS
+RUN bundle install --jobs 4 --retry 5 ${BUNDLE_FLAGS}
 
 COPY . .
 


### PR DESCRIPTION
We need to inject this value into the container, for this to happen it needs to
be declared as an arg.

Also boot up local Redis to mimic production environment.