### PR TITLE
Revert "Bump sprockets from 3.7.2 to 4.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem 'sass-rails', '~> 6.0'
 
 # must explicitly mention sprockets with this version to get round
 # https://blog.heroku.com/rails-asset-pipeline-vulnerability
-gem 'sprockets', '~>4.0.0'
+gem 'sprockets', '~>3.7.2'
 
 # parallel HTTP requests
 gem 'typhoeus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -414,7 +414,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   simplecov
-  sprockets (~> 4.0.0)
+  sprockets (~> 3.7.2)
   therubyracer
   typhoeus
   tzinfo-data

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,9 +1,3 @@
 //= link_tree ../images
-//= link application.js
-//= link application.css
-//= link govuk-template.css
-//= link govuk-template-ie6.css
-//= link govuk-template-ie7.css
-//= link govuk-template-ie8.css
-//= link govuk-template-print.css
-//= link fonts.css
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css


### PR DESCRIPTION
Reverts ministryofjustice/fb-publisher#222

Was broken once deployed:
```
Failed to find a valid digest in the 'integrity' attribute for resource 'https://fb-publisher-test.apps.live-1.cloud-platform.service.justice.gov.uk/assets/govuk-template-8763a4a53960c6be0c507928ba7ef8831adfe55689ce39071ad16955af41954c.css' with computed SHA-256 integrity 'cZ/F9h2pK0ug0bcrAgYnJHHE4dpN+T9n2qT0WzXxOco='. The resource has been blocked.
```
![Screenshot 2019-11-20 at 16 43 29](https://user-images.githubusercontent.com/2160769/69258690-ead3f680-0bb4-11ea-8d73-f9210f520f14.png)
