### PR TITLE
Update Kubernetes resources

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -457,7 +457,7 @@ class KubernetesAdapter
 
   def ingress_rule(service_slug:, hostname:, container_port: 3000)
     <<~ENDHEREDOC
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
       name: #{service_slug}-ingress

--- a/deploy/fb-publisher-chart/templates/deployment.yaml
+++ b/deploy/fb-publisher-chart/templates/deployment.yaml
@@ -1,11 +1,14 @@
 ---
 # web front-end
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "fb-publisher-web-{{ .Values.environmentName }}"
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: "fb-publisher-web-{{ .Values.environmentName }}"
   template:
     metadata:
       labels:
@@ -95,12 +98,15 @@ spec:
                 key: runner_sentry_dsn
 ---
 # workers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "fb-publisher-workers-{{ .Values.environmentName }}"
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: "fb-publisher-workers-{{ .Values.environmentName }}"
   template:
     metadata:
       labels:

--- a/deploy/fb-publisher-chart/templates/ingress.yaml
+++ b/deploy/fb-publisher-chart/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: "fb-publisher-ing-{{ .Values.environmentName }}"


### PR DESCRIPTION
Kubernetes has been upgraded to 1.16. These changes are required for the resources to continue working.

Followed the guide here:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html#resources-deployed-using-helm-charts

https://trello.com/c/w8d8G6RM/696-cloud-platform-kubernetes-update