### PR TITLE
Disable pentest step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,12 +123,6 @@ workflows:
           filters:
             branches:
               only: master
-      - build_and_deploy_to_pentest:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
       - confirm_live_deploy:
           type: approval
           requires:


### PR DESCRIPTION
We do not want to keep changing the pentest environment while testing is ongoing. We can put the step back should we need to deploy out to it.