### PR TITLE
Remove phase banner

### DIFF
--- a/app/assets/stylesheets/govuk_elements.sass
+++ b/app/assets/stylesheets/govuk_elements.sass
@@ -59,6 +59,5 @@
 @import "elements/forms/form-date"
 @import "elements/forms/form-validation"
 @import "elements/breadcrumbs"
-@import "elements/phase-banner"
 @import "elements/components"
 @import "elements/shame"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -34,12 +34,6 @@
 
 = content_for :content do
   %main{ class: "content inner cf", id: "content", role: "main" }
-    .phase-banner
-      %p
-        %strong.phase-tag
-          = t(:phase, scope: [:phase_banner])
-        %span
-          = t(:content_html, scope: [:phase_banner], link_url: '#')
 
     = render partial: 'layouts/flashes'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,11 +79,6 @@ en:
       teams: Teams
     unsigned_user_nav:
       sign_in: Sign in
-  phase_banner:
-    content_html:
-      This is a new service - your <a href="%{link_url}">feedback</a>
-      will help improve it
-    phase: BETA
   services:
     config_params:
       config_param:


### PR DESCRIPTION
# What

The phase banner doesn't exist in any of the other user facing apps. Also the feedback link does not go anywhere.

Until we decide we need either or both, remove it

https://trello.com/c/XdfUzv79/743-publisher-remove-phase-banner

## Before

<img width="988" alt="Screenshot 2020-06-30 at 11 47 29" src="https://user-images.githubusercontent.com/3466862/86118170-35610e00-bac8-11ea-9d4a-d3351e9a1d74.png">


## After

<img width="984" alt="Screenshot 2020-06-30 at 11 47 08" src="https://user-images.githubusercontent.com/3466862/86118180-38f49500-bac8-11ea-9f81-3a35bcad6b9d.png">

