### PR TITLE
All kube8s apps/v1beta1 and apps/v1beta2 should use apps/v1 instead

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -353,7 +353,7 @@ class KubernetesAdapter
                                                environment_slug: @environment.slug)
 
     <<~ENDHEREDOC
-    apiVersion: apps/v1beta2
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: #{name}


### PR DESCRIPTION
[Trello Card](https://trello.com/c/o0wHFl8B/815-unable-to-deploy-forms-to-any-environments)

## Context

It is written in Cloud Platform guides for the kube8s upgrade:

```
t is therefore mandatory to update affected manifests with the replacements shown below before we upgrade the cluster to kubernetes version 1.16.

All resources under apps/v1beta1 and apps/v1beta2 - use apps/v1 instead
```

So the Publisher should respect this.