### PR TITLE
Notify on first publish to Live environment

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,0 +1,21 @@
+require "net/http"
+require "uri"
+
+class NotificationService
+  def self.notify(message)
+    body = {
+      text: message,
+      username: 'Form Builder Publisher',
+      icon_emoji: ':rocket:'
+    }
+
+    uri = URI.parse(ENV['SLACK_PUBLISH_WEBHOOK'])
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.body = body.to_json
+
+    http.request(request)
+  end
+end

--- a/deploy/fb-publisher-chart/templates/deployment.yaml
+++ b/deploy/fb-publisher-chart/templates/deployment.yaml
@@ -185,3 +185,8 @@ spec:
               secretKeyRef:
                 name: fb-publisher-app-secrets-{{ .Values.environmentName }}
                 key: runner_sentry_dsn
+          - name: SLACK_PUBLISH_WEBHOOK
+            valueFrom:
+              secretKeyRef:
+                name: fb-publisher-app-secrets-{{ .Values.environmentName }}
+                key: slack_publish_webhook

--- a/deploy/fb-publisher-chart/templates/secrets.yaml
+++ b/deploy/fb-publisher-chart/templates/secrets.yaml
@@ -9,3 +9,4 @@ data:
   secret_key_base: {{ .Values.secret_key_base }}
   sentry_dsn: {{ .Values.sentry_dsn }}
   runner_sentry_dsn: {{ .Values.runner_sentry_dsn }}
+  slack_publish_webhook: {{ .Values.slack_publish_webhook }}


### PR DESCRIPTION
We would like to be notified whenever a service has been published to the Live environment for the first time. 

This sets a slack notification webhook that is called by the publisher worker upon a successful deployment of a form to Live.

https://trello.com/c/GqbHHLrK/853-notify-on-first-publish-of-a-service-to-live