### PR TITLE
Set SUBMISSION_ENCRYPTION_KEY on deployment of runner containers

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -407,6 +407,8 @@ class KubernetesAdapter
                 value: #{ENV['RUNNER_SENTRY_DSN']}
               - name: SERVICE_SHA
                 value: "#{commit_ref}"
+              - name: SUBMISSION_ENCRYPTION_KEY
+                value: "#{ENV['SUBMISSION_ENCRYPTION_KEY']}"
             image: #{image}
             imagePullPolicy: Always
             ports:

--- a/deploy/fb-publisher-chart/templates/deployment.yaml
+++ b/deploy/fb-publisher-chart/templates/deployment.yaml
@@ -195,3 +195,8 @@ spec:
               secretKeyRef:
                 name: fb-publisher-app-secrets-{{ .Values.environmentName }}
                 key: slack_publish_webhook
+          - name: SUBMISSION_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-publisher-app-secrets-{{ .Values.environmentName }}
+                key: submission_encryption_key

--- a/deploy/fb-publisher-chart/templates/deployment.yaml
+++ b/deploy/fb-publisher-chart/templates/deployment.yaml
@@ -96,6 +96,11 @@ spec:
               secretKeyRef:
                 name: fb-publisher-app-secrets-{{ .Values.environmentName }}
                 key: runner_sentry_dsn
+          - name: SUBMISSION_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-publisher-app-secrets-{{ .Values.environmentName }}
+                key: submission_encryption_key
 ---
 # workers
 apiVersion: apps/v1

--- a/deploy/fb-publisher-chart/templates/secrets.yaml
+++ b/deploy/fb-publisher-chart/templates/secrets.yaml
@@ -10,3 +10,4 @@ data:
   sentry_dsn: {{ .Values.sentry_dsn }}
   runner_sentry_dsn: {{ .Values.runner_sentry_dsn }}
   slack_publish_webhook: {{ .Values.slack_publish_webhook }}
+  submission_encryption_key: {{ .Values.submission_encryption_key }}

--- a/spec/services/kubernetes_adapter_spec.rb
+++ b/spec/services/kubernetes_adapter_spec.rb
@@ -81,6 +81,19 @@ describe KubernetesAdapter do
         expect(value).to eql('runner-sentry-dsn-here')
       end
 
+      it 'sets SUBMISSION_ENCRYPTION_KEY for the runner' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('SUBMISSION_ENCRYPTION_KEY')
+                                  .and_return('runner-submission-encryption-key')
+
+        create_deployment
+
+        hash = YAML.load(File.open(config_dir.join(filename)).read)
+        value = hash.dig('spec', 'template', 'spec', 'containers', 0, 'env')
+                    .find{|k,v| k['name'] == 'SUBMISSION_ENCRYPTION_KEY' }['value']
+        expect(value).to eql('runner-submission-encryption-key')
+      end
+
       it 'sets SERVICE_SHA' do
         create_deployment
 


### PR DESCRIPTION
This key is used to encrypt the submission payload between the runner and the submitter.

The publisher injects the value of the environment value into helm config on publishing of a form.

https://trello.com/c/j6VCPRja/806-encrypt-between-the-runner-the-submitter