### PR TITLE
Navigation content changes on deployments page

### DIFF
--- a/app/views/services/deployments/_environments_nav.html.haml
+++ b/app/views/services/deployments/_environments_nav.html.haml
@@ -6,8 +6,8 @@
       %li
         - if current_env == env.slug.to_s
           %span
-            = env.name
+            = env.form_environment
         - else
-          = link_to env.name, {env: env.slug}
+          = link_to env.form_environment, {env: env.slug}
     %li
       = link_to t('.all_envs_status'), status_service_deployments_path(@service)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,8 +109,8 @@ en:
         delete_confirm: Are you sure you want to delete the deployment of %{name} in the %{environment} environment?
         deleting: Deleting...
       environments_nav:
-        all_envs_status: '(all)'
-        environments: 'Deployments in'
+        all_envs_status: 'All'
+        environments: 'Published on'
       index:
         completed_at: Finished at
         created_at: Job created at
@@ -133,7 +133,7 @@ en:
         status: Status
         actions: Actions
     create:
-      success: Your form has been added.
+      success: Your form has been added
     destroy:
       success: Service "%{service}" deleted successfully
     edit_confirm:


### PR DESCRIPTION
We had previously changed user facing references to Development and Production to Test and Live respectively. This updates the Deployments page for each environment to reflect those same changes.

## Before

<img width="473" alt="Screenshot 2020-09-18 at 17 46 59" src="https://user-images.githubusercontent.com/3466862/93625305-a0402800-f9d9-11ea-848e-1d40dc339f87.png">

## After

<img width="395" alt="Screenshot 2020-09-18 at 17 46 25" src="https://user-images.githubusercontent.com/3466862/93625315-a3d3af00-f9d9-11ea-9eb8-7eb1f687137e.png">

Ignore "localhost". That only appears on dev machines when running locally.

https://trello.com/c/nAEkQ7vK/935-navigation-content-changes-to-all-three-apps