### PR TITLE
Add pingdom endpoint

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,0 +1,5 @@
+class PingController < ApplicationController
+  def show
+    render json: { status: :ok }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   get '/health' => 'health#show'
+  get '/ping.json' => 'ping#show'
   get '/dashboard' => 'dashboard#show'
   get '/welcome' => 'welcome#show'
   get '/signup_not_allowed' => 'user_sessions#signup_not_allowed', as: 'signup_not_allowed'

--- a/spec/controllers/ping_controller_spec.rb
+++ b/spec/controllers/ping_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe PingController do
+  describe '#show' do
+    it 'returns 200 OK' do
+      get :show
+      expect(response.status).to eq(200)
+      expect(response.body).to eq("{\"status\":\"ok\"}")
+    end
+  end
+end


### PR DESCRIPTION
For our public facing services in production we have a pingdom checker which requires a /ping.json endpoint.