### PR TITLE
Mask sensitive config paramaeter values

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,16 @@ module ApplicationHelper
       {action: :create}
     end
   end
+
+  def mask_value(name, value)
+    return value unless Rails.application.config.mask_values.include?(name)
+
+    if value.length <= Rails.application.config.mask_lower_length
+      value.gsub(/./, Rails.application.config.mask_character)
+    elsif value.length <= Rails.application.config.mask_upper_length
+      value.gsub(/.(?=.{2})/, Rails.application.config.mask_character)
+    else
+      value.gsub(/.(?=.{4})/, Rails.application.config.mask_character)
+    end
+  end
 end

--- a/app/views/services/config_params/_config_param.html.haml
+++ b/app/views/services/config_params/_config_param.html.haml
@@ -6,7 +6,7 @@
       %em.font-xsmall
         = t('.empty_value')
     - else
-      = config_param.value
+      = mask_value(config_param.name, config_param.value)
   %td.actions
     - if can?(:edit, config_param)
       = link_to t('.edit'), edit_service_config_param_path(config_param.service, config_param)

--- a/config/initializers/mask_values.rb
+++ b/config/initializers/mask_values.rb
@@ -1,0 +1,7 @@
+Rails.application.config.mask_character = '*'
+
+Rails.application.config.mask_lower_length = 6
+
+Rails.application.config.mask_upper_length = 12
+
+Rails.application.config.mask_values = %w(SERVICE_OUTPUT_JSON_KEY)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -147,4 +147,39 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe '#mask_value' do
+    let(:config_names) { %w(leonardo michelangelo donatello) }
+    let(:six_characters) { '8VBgf8' }
+    let(:twelve_characters) { '8VBgf8LEv8kr' }
+    let(:long_value) { '8VBgf8LEv8krunOd' }
+
+    before do
+      allow(Rails.application.config).to receive(:mask_values).and_return(config_names)
+    end
+
+    context 'six characters' do
+      it 'masks all the character' do
+        expect(mock_controller.mask_value('leonardo', six_characters)).to eq('******')
+      end
+    end
+
+    context 'twelve characters' do
+      it 'masks all but the last 2 characters' do
+        expect(mock_controller.mask_value('michelangelo', twelve_characters)).to eq('**********kr')
+      end
+    end
+
+    context 'more than twelve characters' do
+      it 'masks all but the last 4 characters' do
+        expect(mock_controller.mask_value('donatello', long_value)).to eq('************unOd')
+      end
+    end
+
+    context 'config name not in mask values config' do
+      it 'does not mask any characters' do
+        expect(mock_controller.mask_value('raphael', long_value)).to eq(long_value)
+      end
+    end
+  end
 end


### PR DESCRIPTION
There are some configuration parameters that are sensitive and we should mask these in the UI.

https://trello.com/c/wHAoHXxc/942-hide-json-output-key-in-publisher