### PR TITLE
Prevent editing of masked config parameters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,8 +29,12 @@ module ApplicationHelper
     end
   end
 
+  def masked_config?(name)
+    Rails.application.config.mask_values.include?(name)
+  end
+
   def mask_value(name, value)
-    return value unless Rails.application.config.mask_values.include?(name)
+    return value unless masked_config?(name)
 
     if value.length <= Rails.application.config.mask_lower_length
       value.gsub(/./, Rails.application.config.mask_character)

--- a/app/views/services/config_params/_config_param.html.haml
+++ b/app/views/services/config_params/_config_param.html.haml
@@ -8,7 +8,7 @@
     - else
       = mask_value(config_param.name, config_param.value)
   %td.actions
-    - if can?(:edit, config_param)
+    - if can?(:edit, config_param) && !masked_config?(config_param.name)
       = link_to t('.edit'), edit_service_config_param_path(config_param.service, config_param)
     - if can?(:destroy, config_param)
       = button_to t('.delete'),

--- a/spec/features/config_params_spec.rb
+++ b/spec/features/config_params_spec.rb
@@ -19,6 +19,7 @@ describe "visiting a service's config params page" do
 
     context 'when adding new environment variables' do
       before do
+        allow(Rails.application.config).to receive(:mask_values).and_return([name])
         visit "/services/#{service.slug}/configuration"
         fill_in('Name', with: name)
         fill_in('Value', with: value)
@@ -45,6 +46,12 @@ describe "visiting a service's config params page" do
 
         it 'displays error message' do
           expect(page).to have_content('Name has already been taken')
+        end
+      end
+
+      context 'masked environment variables' do
+        it 'does not allow masked variables to be edited' do
+          expect(page).to_not have_content('Edit')
         end
       end
     end


### PR DESCRIPTION
As we now mask certain configuration parameters, if someone tries to edit them they are shown in plain text.

Here we remove the ability to edit the config parameter entirely. A user will need to delete and re add the value if it changes.

<img width="874" alt="Screenshot 2020-09-25 at 14 02 53" src="https://user-images.githubusercontent.com/3466862/94272551-1cd38900-ff3b-11ea-974e-dc3f17d7b414.png">