### PR TITLE
Mitigate Omniauth CSRF vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'jquery-rails'
 
 gem 'omniauth' #, '~> 1.6.1'
 gem 'omniauth-auth0', '~> 2.4.1'
+gem 'omniauth-rails_csrf_protection', '~> 0.1'
 
 # Pagination
 gem 'pagy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
     omniauth-oauth2 (1.7.0)
       oauth2 (~> 1.4)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     pagy (3.10.0)
     parallel (1.20.1)
     parser (2.7.2.0)
@@ -384,6 +387,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.4)
   omniauth
   omniauth-auth0 (~> 2.4.1)
+  omniauth-rails_csrf_protection (~> 0.1)
   pagy
   pg (>= 0.18, < 2.0)
   puma (~> 5.0)

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -15,9 +15,9 @@
 
   <div>
     <% if Rails.env.development? %>
-      <%= link_to t('.sign_in'), '/auth/developer', class: 'button button-start' %>
+      <%= link_to t('.sign_in'), '/auth/developer', method: :post, class: 'button button-start' %>
     <% else %>
-      <%= link_to t('.sign_in'), '/auth/auth0', class: 'button button-start' %>
+      <%= link_to t('.sign_in'), '/auth/auth0', method: :post, class: 'button button-start' %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/_unsigned_user_nav.html.erb
+++ b/app/views/layouts/_unsigned_user_nav.html.erb
@@ -1,9 +1,9 @@
 <ul id="proposition-links">
   <li>
     <% if Rails.env.development? %>
-      <%= link_to t('.sign_in'), '/auth/developer' %>
+      <%= link_to t('.sign_in'), '/auth/developer', method: :post %>
     <% else %>
-      <%= link_to t('.sign_in'), '/auth/auth0' %>
+      <%= link_to t('.sign_in'), '/auth/auth0', method: :post %>
     <% end %>
   </li>
 </ul>

--- a/spec/controllers/omniauth_csrf_vulnerability_spec.rb
+++ b/spec/controllers/omniauth_csrf_vulnerability_spec.rb
@@ -1,0 +1,21 @@
+# Make sure that https://nvd.nist.gov/vuln/detail/CVE-2015-9284 is mitigated
+require 'rails_helper'
+
+RSpec.describe 'CVE-2015-9284', type: :request do
+  describe 'POST /auth/:provider without CSRF token' do
+    before do
+      @allow_forgery_protection = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    it do
+      expect {
+        post "/auth/auth0"
+      }.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = @allow_forgery_protection
+    end
+  end
+end


### PR DESCRIPTION
Omniauth has a severe CSRF vulnerability. In order to mitigate it there are mainly two actions to take:
1. Turn GET requests links to `/auth/:provider` routes into POST requests.
2. Install `omniauth-rails_csrf_protection` gem.

LINKS
----------------------------------------------------------------------
CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284

Solution directions:
https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284