### PR TITLE
EKS Migration: Bearer token and AWS weighting

### DIFF
--- a/deploy-eks/fb-publisher-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-publisher-chart/templates/deployment.yaml
@@ -158,7 +158,7 @@ spec:
           - name: KUBECTL_BEARER_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.KUBECTL_BEARER_TOKEN }}
+                name: {{ .Values.bearer_token }}
                 key: token
           - name: DATABASE_URL
             valueFrom:

--- a/deploy-eks/fb-publisher-chart/templates/ingress.yaml
+++ b/deploy-eks/fb-publisher-chart/templates/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "fb-publisher-ing-{{ .Values.environmentName }}"
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "fb-publisher-ing-{{ .Values.environmentName }}-formbuilder-publisher-{{ .Values.environmentName }}-green"
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/aws-weight: "{{ .Values.eks_weighting }}"
 spec:
   tls:
   - hosts:

--- a/deploy-eks/fb-publisher-chart/templates/ingress.yaml
+++ b/deploy-eks/fb-publisher-chart/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - fb-publisher-{{ .Values.environmentName }}.apps.live-1.cloud-platform.service.justice.gov.uk
+    - fb-publisher-{{ .Values.environmentName }}.apps.live.cloud-platform.service.justice.gov.uk
   rules:
-  - host: fb-publisher-{{ .Values.environmentName }}.apps.live-1.cloud-platform.service.justice.gov.uk
+  - host: fb-publisher-{{ .Values.environmentName }}.apps.live.cloud-platform.service.justice.gov.uk
     http:
       paths:
       - path: /

--- a/deploy-eks/fb-publisher-chart/templates/ingress.yaml
+++ b/deploy-eks/fb-publisher-chart/templates/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "fb-publisher-ing-{{ .Values.environmentName }}"
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "fb-publisher-ing-{{ .Values.environmentName }}-formbuilder-publisher-{{ .Values.environmentName }}-green"
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:

--- a/deploy/fb-publisher-chart/templates/deployment.yaml
+++ b/deploy/fb-publisher-chart/templates/deployment.yaml
@@ -158,7 +158,7 @@ spec:
           - name: KUBECTL_BEARER_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.KUBECTL_BEARER_TOKEN }}
+                name: {{ .Values.bearer_token }}
                 key: token
           - name: DATABASE_URL
             valueFrom:

--- a/deploy/fb-publisher-chart/templates/ingress.yaml
+++ b/deploy/fb-publisher-chart/templates/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "fb-publisher-ing-{{ .Values.environmentName }}"
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "fb-publisher-ing-{{ .Values.environmentName }}-formbuilder-publisher-{{ .Values.environmentName }}-blue"
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
 spec:
   tls:
   - hosts:

--- a/deploy/fb-publisher-chart/templates/ingress.yaml
+++ b/deploy/fb-publisher-chart/templates/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "fb-publisher-ing-{{ .Values.environmentName }}"
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "fb-publisher-ing-{{ .Values.environmentName }}-formbuilder-publisher-{{ .Values.environmentName }}-blue"
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/aws-weight: "{{ .Values.k8s_weighting }}"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
[Trello](https://trello.com/c/JAx6UE1D/2038-eks-021-spike-to-step-through-10-points-publisher)

### Adapt token to be used for both EKS and K8S

### Move all traffic to EKS cluster
 
### Add AWS weighting 
Add new env variables to give us better control over traffic to the
two clusters.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>