### PR TITLE
Increase Runner default replicas

### DIFF
--- a/app/services/resourcing_service.rb
+++ b/app/services/resourcing_service.rb
@@ -59,7 +59,7 @@ class ResourcingService
   private
 
   def default_deployment_replicas
-    2
+    4
   end
 
   def default_resources

--- a/spec/services/kubernetes_adapter_spec.rb
+++ b/spec/services/kubernetes_adapter_spec.rb
@@ -162,7 +162,7 @@ describe KubernetesAdapter do
         hash = YAML.load(File.open(config_dir.join(filename)).read)
         replicas = hash.dig('spec', 'replicas')
 
-        expect(replicas).to eql(2)
+        expect(replicas).to eql(4)
       end
 
       context do


### PR DESCRIPTION
Given the increase in bot traffic, until we have a broader mitigation
increase the replica count for reach form to 4.