### PR TITLE
Deny public users access to Publisher in Test

### DIFF
--- a/config/initializers/moj_forms_team.rb
+++ b/config/initializers/moj_forms_team.rb
@@ -1,0 +1,15 @@
+MOJ_FORMS_TEAM = [
+  'ajiri.owuasu@digital.justice.gov.uk',
+  'brendan.butler@digital.justice.gov.uk',
+  'chris.pymm@digital.justice.gov.uk',
+  'claire.bowman@digital.justice.gov.uk',
+  'fabien.marry@digital.justice.gov.uk',
+  'holly.challenger@digital.justice.gov.uk',
+  'mark.jefferson@digital.justice.gov.uk',
+  'matt.tei@digital.justice.gov.uk',
+  'natalie.seeto@digital.justice.gov.uk',
+  'sijy.mathew@digital.justice.gov.uk',
+  'steven.burnell@digital.justice.gov.uk',
+].freeze
+
+Rails.application.config.moj_forms_team = MOJ_FORMS_TEAM

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
         invalid: "is invalid (can only contain lower case letters or numbers, '-' or '.', and must start and end with a letter or number)"
     team:
       super_admin: "only one team can be assigned super admin rights"
+    access_denied: "This Publisher is only available to members of the MoJ Forms team. Please visit the <a href='https://fb-publisher-live.apps.live-1.cloud-platform.service.justice.gov.uk'>Live Publisher</a>"
   helpers:
     hint:
       service:


### PR DESCRIPTION
We only wish to allow access to the Publisher in Test for members of the
MoJ Forms team. All other end users should use the Publisher in the Live
environment.