### PR TITLE
Publish forms to the new EKS cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,10 +122,10 @@ workflows:
           include_job_number_field: false
           requires:
             - build_and_deploy_to_test
-      - confirm_live_deploy:
-          type: approval
-          requires:
-            - build_and_deploy_to_test
-      - build_and_deploy_to_live:
-          requires:
-            - confirm_live_deploy
+      # - confirm_live_deploy:
+      #     type: approval
+      #     requires:
+      #       - build_and_deploy_to_test
+      # - build_and_deploy_to_live:
+      #     requires:
+      #       - confirm_live_deploy

--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -468,7 +468,7 @@ class KubernetesAdapter
         kubernetes.io/ingress.class: "nginx"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/custom-http-errors: "400, 401, 403, 404, 500, 503"
-        external-dns.alpha.kubernetes.io/set-identifier: #{service_slug}-ingress-#{@environment.namespace}-blue
+        external-dns.alpha.kubernetes.io/set-identifier: #{service_slug}-ingress-#{@environment.namespace}-green
         external-dns.alpha.kubernetes.io/aws-weight: "100"
     spec:
       tls:


### PR DESCRIPTION
This changes the ingress configuration for all the forms that are
published by the Publisher going forward. Setting the dns annotation to
green is required for the new cluster.