### PR TITLE
Update kubernetes controller configs

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -462,12 +462,12 @@ class KubernetesAdapter
     apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
-      name: #{service_slug}-ingress-new
+      name: #{service_slug}-ingress
       namespace: #{@environment.namespace}
       annotations:
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/custom-http-errors: "400, 401, 403, 404, 500, 503"
-        external-dns.alpha.kubernetes.io/set-identifier: #{service_slug}-ingress-new-#{@environment.namespace}-green
+        external-dns.alpha.kubernetes.io/set-identifier: #{service_slug}-ingress-#{@environment.namespace}-green
         external-dns.alpha.kubernetes.io/aws-weight: "100"
     spec:
       ingressClassName: default

--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -462,15 +462,15 @@ class KubernetesAdapter
     apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
-      name: #{service_slug}-ingress
+      name: #{service_slug}-ingress-new
       namespace: #{@environment.namespace}
       annotations:
-        kubernetes.io/ingress.class: "nginx"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/custom-http-errors: "400, 401, 403, 404, 500, 503"
-        external-dns.alpha.kubernetes.io/set-identifier: #{service_slug}-ingress-#{@environment.namespace}-green
+        external-dns.alpha.kubernetes.io/set-identifier: #{service_slug}-ingress-new-#{@environment.namespace}-green
         external-dns.alpha.kubernetes.io/aws-weight: "100"
     spec:
+      ingressClassName: default
       tls:
         - hosts:
           - #{hostname}

--- a/deploy-eks/fb-publisher-chart/templates/ingress.yaml
+++ b/deploy-eks/fb-publisher-chart/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: "fb-publisher-ing-{{ .Values.environmentName }}-formbuilder-publisher-{{ .Values.environmentName }}-green"
     external-dns.alpha.kubernetes.io/aws-weight: "{{ .Values.eks_weighting }}"
 spec:
+  ingressClassName: default
   tls:
   - hosts:
     - fb-publisher-{{ .Values.environmentName }}.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
This updates both the Runner and Publisher ingress configurations to make use of the newer Kubernetes controller version 1.2

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <[hellema.ibrahim@digital.justice.gov.uk](mailto:hellema.ibrahim@digital.justice.gov.uk)>