### PR TITLE
Unpin Docker version in CircleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker: &remote_docker
-          version: 20.10.11
           docker_layer_caching: true
       - run:
           name: test


### PR DESCRIPTION
CircleCI will be keeping the Docker executor up to date on a rolling basis.

Checklist:
- [x] [CircleCI run](https://app.circleci.com/pipelines/github/ministryofjustice/fb-publisher/1722/workflows/f2195e17-8a75-41f8-808f-7cdecea82d7d)
- [x] Access [Test Publisher](https://fb-publisher-test.apps.live.cloud-platform.service.justice.gov.uk/services)
- [x] Successfully publish form to test in Test publisher