### PR TITLE
Stop using the beta versions of kubernetes ingress controllers

### DIFF
--- a/app/services/kubernetes_adapter.rb
+++ b/app/services/kubernetes_adapter.rb
@@ -459,7 +459,7 @@ class KubernetesAdapter
 
   def ingress_rule(service_slug:, hostname:, container_port: 3000)
     <<~ENDHEREDOC
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: #{service_slug}-ingress
@@ -480,9 +480,12 @@ class KubernetesAdapter
         http:
           paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: #{service_slug}
-              servicePort: #{container_port}
+              service:
+                name: #{service_slug}
+                port:
+                  number: #{container_port}
     ENDHEREDOC
   end
 end

--- a/deploy-eks/fb-publisher-chart/templates/ingress.yaml
+++ b/deploy-eks/fb-publisher-chart/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "fb-publisher-ing-{{ .Values.environmentName }}"
@@ -15,6 +15,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: fb-publisher-svc-{{ .Values.environmentName }}
-          servicePort: 80
+          service:
+            name: fb-publisher-svc-{{ .Values.environmentName }}
+            port:
+              number: 80


### PR DESCRIPTION
All beta Ingress API versions such as extensions/v1beta1 and networking.k8s.io/v1beta1 have been deprecated and are not available in Kubernetes v1.22 or the new nginx-ingress-controller v1.2

Change the apiVersion to networking.k8s.io/v1

Add pathType: ImplementationSpecific after path: /

For serviceName, rename -backend.serviceName to -backend.service.name

For String servicePort, rename -backend.servicePort to -backend.service.port.name

For Numeric servicePort, rename -backend.servicePort to -backend.service.port.number