### PR TITLE
Adding new users to access the Publisher

### DIFF
--- a/config/initializers/moj_forms_team.rb
+++ b/config/initializers/moj_forms_team.rb
@@ -1,7 +1,10 @@
 MOJ_FORMS_TEAM = [
+  'assma.banaris@digital.justice.gov.uk',
   'chris.pymm@digital.justice.gov.uk',
   'claire.bowman@digital.justice.gov.uk',
+  'darren.rooke@digital.justice.gov.uk',
   'fabien.marry@digital.justice.gov.uk',
+  'javid.ali@digital.justice.gov.uk',
   'hellema.ibrahim@digital.justice.gov.uk',
   'mark.jefferson@digital.justice.gov.uk',
   'matt.tei@digital.justice.gov.uk',


### PR DESCRIPTION
This PR adds new team members and user in the Central Digital team to access the Publisher. All need access to make changes with legacy forms and the ability to republish.